### PR TITLE
Add a link to JIRA Pipeline compatibility status

### DIFF
--- a/src/corg/development-tools-and-process/quality-assurance-and-continuous-integration/jenkins-plugins/jenkins-pipeline-usage.md
+++ b/src/corg/development-tools-and-process/quality-assurance-and-continuous-integration/jenkins-plugins/jenkins-pipeline-usage.md
@@ -111,6 +111,8 @@ git poll: false, url: 'git@github.com:nuxeo/nuxeo.git'
 step([$class: 'JiraIssueUpdater', issueSelector: [$class: 'DefaultIssueSelector'], scm: scm])
 ```
 
+See https://github.com/jenkinsci/jira-plugin/blob/master/COMPATIBILITY.md#current-status
+
 ## Email Usage
 
 At the time of this writing, the Email-ext plugin is not compatible with pipelines.


### PR DESCRIPTION
About JIRA pipeline integration, point to the COMPATIBILITY.md file stating the current status.