### PR TITLE
Table Formatting: Corrected

### DIFF
--- a/src/nxdoc/nuxeo-server/rest-api/json-marshalling/parameterizing-reusing-marshallers.md
+++ b/src/nxdoc/nuxeo-server/rest-api/json-marshalling/parameterizing-reusing-marshallers.md
@@ -238,7 +238,7 @@ Object o = ctx.getParameter("paramName");
 </pre>
 
 <pre>
-List<Object> list = ctx.getParameters("paramName");
+List&lt;Object&gt; list = ctx.getParameters("paramName");
 </pre>
 
 <pre>
@@ -297,7 +297,7 @@ ctx.setParameterValues("properties", "dublincore", "file");
 <td colspan="1">
 
 <pre>
-Set<String> properties = ctx.getProperties();
+Set&lt;String&gt; properties = ctx.getProperties();
 </pre>
 
 </td>
@@ -355,7 +355,7 @@ ctx.setParameterValues("fetch.objectType", "part1", "part2");
 <td colspan="1">
 
 <pre>
-Set<String> toLoad = ctx.getFetched("objectType");
+Set&lt;String&gt; toLoad = ctx.getFetched("objectType");
 </pre>
 
 </td>
@@ -411,7 +411,7 @@ ctx.setParameterValues("enrichers.objectType", "children", "acl");
 <td colspan="1">
 
 <pre>
-Set<String> enricherToActivate = ctx.getEnrichers("objectType");
+Set&lt;String&gt; enricherToActivate = ctx.getEnrichers("objectType");
 </pre>
 
 </td>
@@ -459,7 +459,7 @@ ctx.setParameterValues("translate.objectType", "elementToTranslate");
 <td colspan="1">
 
 <pre>
-Set<String> toTranslate = ctx.getTranslated("objectType");
+Set&lt;String&gt; toTranslate = ctx.getTranslated("objectType");
 </pre>
 
 </td>

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-532-to-540/upgrade-to-54-and-jboss-5.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-532-to-540/upgrade-to-54-and-jboss-5.md
@@ -60,40 +60,47 @@ The solution is simple: `nuxeo.war` tree should not be at root of the JAR.
 
 Sample directory structure:
 
-<div class="table-scroll"><table class="hover"><tbody><tr><th colspan="1">
-
-<span style="color: rgb(0,0,0);">Before (Jboss 4.2)</span>
-
-</th><th colspan="1">
-
-<span style="color: rgb(0,0,0);">After (Jboss 5.1)</span>
-
-</th></tr><tr><td colspan="1">
-
-<span style="color: rgb(51,51,51);">.</span>
-<span style="color: rgb(51,51,51);">`-- src</span>
-<span style="color: rgb(51,51,51);">`-- main</span>
-<span style="color: rgb(51,51,51);">|-- java</span>
-<span style="color: rgb(51,51,51);">`-- resources</span>
-<span style="color: rgb(51,51,51);">|-- META-INF</span>
-<span style="color: rgb(51,51,51);">|-- nuxeo.war</span>
-<span style="color: rgb(51,51,51);">| `-- my_page.xhtml</span>
-<span style="color: rgb(51,51,51);">`-- OSGI-INF</span>
-
-</td><td colspan="1">
-
+<div class="table-scroll">
+    <table class="hover">
+        <thead>
+            <tr>
+                <th>Before (Jboss 4.2)</th>
+                <th>After (Jboss 5.1)</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <pre>
 .
-`-- src
-`-- main
+\`-- src
+\`-- main
 |-- java
-`-- resources
+\`-- resources
+|-- META-INF
+|-- nuxeo.war
+| \`-- my_page.xhtml
+\`-- OSGI-INF
+                    </pre>
+                </td>
+                <td>
+                    <pre>
+.
+\`-- src
+\`-- main
+|-- java
+\`-- resources
 |-- META-INF
 |-- OSGI-INF
-<span style="color: rgb(255,0,0);">`-- web</span>
-`-- nuxeo.war
-`-- my_page.xhtml
-
-</td></tr></tbody></table></div>
+\`-- web
+\`-- nuxeo.war
+\`-- my_page.xhtml
+                    </pre>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 This implies a small change in the deployment-fragment:
 

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-532-to-540/upgrade-to-54-and-jboss-5.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-532-to-540/upgrade-to-54-and-jboss-5.md
@@ -115,11 +115,11 @@ After (Jboss 5.1)
 </th></tr><tr><td colspan="1">
 
 ```
-<install>
- <unzip from="${bundle.fileName}" to="/" >
- <include>nuxeo.war/**</include>
- </unzip>
- </install>
+    <install>
+    <unzip from="${bundle.fileName}" to="/" >
+    <include>nuxeo.war/**</include>
+    </unzip>
+    </install>
 
 ```
 
@@ -193,22 +193,22 @@ Before (Jboss 4.2)
 After (Jboss 5)
 
 </th></tr><tr><td colspan="1">
-
+<pre>
 @Local(WSAuditLocal.class)
 @Stateless
 @Remote(WSAudit.class)
 @WebService(name = "WSAuditInterface", serviceName = "WSAuditService")
 @SOAPBinding(style = Style.DOCUMENT)
 public class WSAuditBean extends AbstractNuxeoWebService implements
-
+</pre>
 </td><td colspan="1">
-
+<pre>
 @Local(WSAuditLocal.class)
 @Remote(WSAudit.class)
 @WebService(name = "WSAuditInterface", serviceName = "WSAuditService")
 @SOAPBinding(style = Style.DOCUMENT)
 public class WSAuditBean extends AbstractNuxeoWebService implements
-
+</pre>
 </td></tr></tbody></table></div>
 
 #### SUN-JAX-WS vs JBossWS binding
@@ -241,11 +241,12 @@ SUN-JAX-WS binding
 `<url-pattern>/webservices/nuxeoaudit</url-pattern>`
 `</servlet-mapping>`
 `</extension>`
+
 NB: Yes, you declare you Bean as a servlet even if it does not implement the needed interface!
 
 </td><td colspan="1">
 
-`<!<span style="text-decoration: line-through;">- SUN JAXWS / Metro EndPoint Declaration -</span>>`
+<span style="text-decoration: line-through;">`<!SUN JAXWS / Metro EndPoint Declaration>`</span>
 `<extension target="jaxws#ENDPOINT">`
 `<endpoint name="nuxeoaudit"`
 `implementation="org.nuxeo.ecm.platform.audit.ws.WSAuditBean"`
@@ -360,35 +361,35 @@ If you override a template, check the directories. For instance, here are the `d
 
 <div class="table-scroll"><table class="hover"><tbody><tr><th colspan="1">
 
-<span style="color: rgb(0,0,0);">Before (Jboss 4.2)</span>
+Before (Jboss 4.2)
 
 </th><th colspan="1">
 
-<span style="color: rgb(0,0,0);">After (Jboss 5.1)</span>
+After (Jboss 5.1)
 
 </th></tr><tr><td colspan="1">
-
+<pre>
 .
 |-- config
 | |-- default-repository-config.xml
-| `-- sql.properties
+| \`-- sql.properties
 |-- datasources
 | |-- default-repository-ds.xml
-| `-- unified-nuxeo-ds.xml
-`-- nuxeo.defaults
-
+| \`-- unified-nuxeo-ds.xml
+\`-- nuxeo.defaults
+</pre>
 </td><td colspan="1">
-
+<pre>
 .
 |-- nuxeo-ds.xml
 |-- nuxeo.defaults
-`-- nuxeo.ear
+\`-- nuxeo.ear
 |-- META-INF
-| `-- default-repository-ds.xml
-`-- config
+| \`-- default-repository-ds.xml
+\`-- config
 |-- default-repository-config.xml
-`-- sql.properties
-
+\`-- sql.properties
+</pre>
 </td></tr></tbody></table></div>
 
 As defined in `nuxeo.defaults` ("`default.target=server/default/deploy`"), the target directory of this template is now `server/default/deploy` instead of `server/default/deploy/nuxeo.ear`.
@@ -405,10 +406,11 @@ Deprecated compliance artifacts with old resources were removed.
 
 `nuxeo-platform-ear` and `nuxeo-distribution-dm` now only contain:
 
+```
 nuxeo.ear/
 |-- bundles
 `-- lib
-
+```
 All resources files are generated from templates directories.
 
 Also, the default EAR archives contain in `lib/` all third-party libraries from the dependency tree (only duplicates are removed). The filtering of provided libraries is done when building the server distribution (JBoss, Tomcat, ...).


### PR DESCRIPTION
Table corrected. This is partly an example too for others that might need similar formatting.

_Note:_ The single backticks need escaping with a `\`