### PR TITLE
Update nuxeo-elements-tutorial.md

### DIFF
--- a/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
+++ b/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
@@ -53,7 +53,13 @@ improve it using both `nuxeo-elements` and `nuxeo-ui-elements`.
 
     Nuxeo CLI will ask you several questions about the artifact name, etc.
 
-3.  Run gulp to run the application and see what has been generated.
+3.  Change current directory to nuxeo-elements-sample-web, where gulpfile.js has been created
+
+    ```bash
+    $ cd nuxeo-elements-sample-web
+    ```
+
+4.  Run gulp to run the application and see what has been generated.
 
     ```bash
     $ gulp serve


### PR DESCRIPTION
Add one additional step to avoid this error message:

$ gulp serve
[12:41:25] Local gulp not found in ~/workspace/nuxeo-elements-sample
[12:41:25] Try running: npm install gulp