### PR TITLE
Update nuxeo-elements-tutorial.md

### DIFF
--- a/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
+++ b/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
@@ -29,6 +29,10 @@ improve it using both `nuxeo-elements` and `nuxeo-ui-elements`.
 
 ## Scaffolding
 
+{{#> callout type='note'}}
+We recommend you to use [Nuxeo CLI]({{page page='nuxeo-cli'}}) for scaffolding. Using this setup, you'll not have to take care about packaging and deploying your application in Nuxeo. Use [Polymer CLI](https://github.com/Polymer/polymer-cli) only if you know that your application will live outside the Nuxeo Server.
+{{/callout}}
+
 ### As a Nuxeo Bundle
 
 1.  Install Nuxeo CLI and scaffold the project:
@@ -131,6 +135,10 @@ Let's plug this application into the Nuxeo instance and change the hardcoded use
 2.  Plug our new element into `my-app.html`, so that it is available from PSK's sidebar.
 
     Add a new entry to *Drawer content*:
+
+    {{#> callout type='note'}}
+    Depending of your setup, links differ if you generated with [Polymer CLI](https://github.com/Polymer/polymer-cli).
+    {{/callout}}
 
     {{#> panel type='code' heading='src/my-app.html'}}
     ```xml

--- a/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
+++ b/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
@@ -134,7 +134,7 @@ Let's plug this application into the Nuxeo instance and change the hardcoded use
 
     {{#> panel type='code' heading='src/my-app.html'}}
     ```xml
-    <a name="doc-reader" href="/doc-reader">Document Reader</a>
+    <a name="doc-reader" href="/#doc-reader">Document Reader</a>
     ```
     {{/panel}}
 

--- a/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
+++ b/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
@@ -137,7 +137,7 @@ Let's plug this application into the Nuxeo instance and change the hardcoded use
     Add a new entry to *Drawer content*:
 
     {{#> callout type='note'}}
-    Depending of your setup, links differ if you generated with [Polymer CLI](https://github.com/Polymer/polymer-cli).
+    Depending on your setup, links differ if you generated with [Polymer CLI](https://github.com/Polymer/polymer-cli).
     {{/callout}}
 
     {{#> panel type='code' heading='src/my-app.html'}}


### PR DESCRIPTION
I have found other error in the tutorial

<a name="doc-reader" href="/doc-reader">Document Reader</a>

this doesn't work. You must add a # int the link

<a name="doc-reader" href="#/doc-reader">Document Reader</a>

and works