### PR TITLE
Use getActingUser() instead of originatingUser

### DIFF
--- a/src/nxdoc/nuxeo-server/workflow/variables-available-in-the-automation-context.md
+++ b/src/nxdoc/nuxeo-server/workflow/variables-available-in-the-automation-context.md
@@ -138,7 +138,7 @@ In the chains run on nodes (Input chain, output chain, transition and escalation
 *   `nodeStartTime`: The time when the node was started, useful for example when computing a due date (Eg: MVEL Due date expression: `nodeStartTime.days(8)`)
 *   `nodeEndTime`: The time when the node was ended.
 *   `nodeLastActor`: The last actor on the node. Useful for instance to know who closed a task when the task was assigned to a group.
-*   `CurrentUser.originatingUser`: All the automation operations executed by the workflow engine are executed using a temporary unrestricted session (if the current user is not an administrator, this is a session with the user "system"). This variable allows you to fetch the current user.
+*   `CurrentUser.getActingUser()`: All the automation operations executed by the workflow engine are executed using a temporary unrestricted session (if the current user is not an administrator, this is a session with the user "system"). This function returns the ID of the actual user performing the task.
 *   `ChainParameters`: A hashmap, used like this: `ChainParameters['my_chain_parameter']`. Since 5.7.2, all chains are able to contain parameters as operation to be used from the automation context along their execution.
 *   `workflowInstanceId`: The id of the workflow instance.
 *   `NodeVariables["tasks"]`: Holds information about all tasks created by a node. Is a list of objects of type [TaskInfo](http://community.nuxeo.com/api/nuxeo/8.10/javadoc/org/nuxeo/ecm/platform/routing/core/impl/GraphNode.TaskInfo.html). You can iterate on this list and fetch for every task: the lifecycle state (ended or not), the user who ended the task, the comment if any, and the id of the button the user clicked to complete the task (status).

--- a/src/nxdoc/nuxeo-server/workflow/workflow-engine-faq.md
+++ b/src/nxdoc/nuxeo-server/workflow/workflow-engine-faq.md
@@ -230,7 +230,7 @@ history:
     You just need to use a node variable called "comment" and you'll find all the comments stored in the Event log, on the "Workflow task completed" event.
 
 *   {{> anchor 'current-user-variable'}}**How can I get the current user name in an operation executed by the workflow?**
-    All the automation operations executed by the workflow engine are executed using a temporary unrestricted session (if the current user is not an administrator, this is a session with the user "system"). In order to fetch the current user, you have to use: `CurrentUser.originatingUser==null ? CurrentUser.name : CurrentUser.originatingUser`.
+    All the automation operations executed by the workflow engine are executed using a temporary unrestricted session (if the current user is not an administrator, this is a session with the user "system"). In order to fetch the current user id, you can to use: `CurrentUser.getActingUser()`.
 
 *   **Is the availability filter configured on the workflow also evaluated when the workflow is started using the operation "StartWorkflow"?**
     No, this filter is actually an [Action Filter](/x/EYAO) used to control the visibility of workflow models in the list of workflows displayed by the widget type "Workflow Process".

--- a/src/nxdoc/nuxeo-server/workflow/workflow-how-to-index/how-to-follow-a-transition-if-user-is-member-of-a-group.md
+++ b/src/nxdoc/nuxeo-server/workflow/workflow-how-to-index/how-to-follow-a-transition-if-user-is-member-of-a-group.md
@@ -89,7 +89,7 @@ Fn.getPrincipal(workflowInitiator).isMemberOf("managers")
 
 ```
 
-This expression will be true if the workflowInitiator is a member of the managers group. Replace the group by the one you need and "workflowInitiator" by any other user you would need. If you need to filter on the current user, you can use `CurrentUser.originatingUser` as stated in the page [Variables Available in the Automation Context]({{page page='variables-available-in-the-automation-context'}}).
+This expression will be true if the workflowInitiator is a member of the managers group. Replace the group by the one you need and "workflowInitiator" by any other user you would need. If you need to filter on the current user, you can use `CurrentUser.getActingUser()` as stated in the page [Variables Available in the Automation Context]({{page page='variables-available-in-the-automation-context'}}).
 
 
 * * *


### PR DESCRIPTION
`originatingUser` returns null in a workflow context, whereas `getActingUser()` works in all contexts.