### PR TITLE
GnuPG is missing since Debian 9 (APT 1.4.7)

### DIFF
--- a/src/nxdoc/nuxeo-server/installation/installing-the-nuxeo-platform-on-linux.md
+++ b/src/nxdoc/nuxeo-server/installation/installing-the-nuxeo-platform-on-linux.md
@@ -397,6 +397,17 @@ This requires X11.
 
 {{! multiexcerpt name='apt-repo-install-terminal'}}
 
+    {{#> callout type='tip' }}
+
+    The GnuPG package may be missing since Debian Stretch (9):
+    
+    ```
+    sudo apt-get install gnupg
+    ```
+
+    {{/callout}}
+
+
 1.  Import the Nuxeo key.
 
     ```bash

--- a/src/nxdoc/nuxeo-server/installation/installing-the-nuxeo-platform-on-linux.md
+++ b/src/nxdoc/nuxeo-server/installation/installing-the-nuxeo-platform-on-linux.md
@@ -387,26 +387,20 @@ This requires X11.
 6.  Open a browser and type the URL <a>http://localhost:8080/nuxeo/.</a>
     The [startup wizard]({{page page='configuration-wizard'}}) is displayed so you can setup your Nuxeo platform and select the module you want to install.
 
-&nbsp;
-
 {{! /multiexcerpt}}
 
-&nbsp;
 
 ### From the Terminal
 
 {{! multiexcerpt name='apt-repo-install-terminal'}}
 
-    {{#> callout type='tip' }}
 
-    The GnuPG package may be missing since Debian Stretch (9):
-    
-    ```
-    sudo apt-get install gnupg
-    ```
-
-    {{/callout}}
-
+{{#> callout type='tip' }}
+The GnuPG package may be missing since Debian Stretch (9):
+```
+sudo apt-get install gnupg
+```
+{{/callout}}
 
 1.  Import the Nuxeo key.
 
@@ -431,6 +425,7 @@ This requires X11.
     ```
 
     {{/callout}}
+
 3.  Update your APT cache.
 
     ```bash


### PR DESCRIPTION
The apt package changed gnupg|gnupg2 from Depends to Recommends (since APT 1.4.7; ie since Debian 9).
So, `gnupg` may be missing for using `apt-key` and must be installed before.

https://answers.nuxeo.com/general/q/4348e156f6e04e96ba4eda25ed7ad31b/Problem-with-installing-Nuxeo-on
http://metadata.ftp-master.debian.org/changelogs/main/a/apt/apt_1.4.7_changelog
> apt (1.3~exp1) experimental; urgency=medium
> * move gnupg|gnupg2 from apt Depends to Recommends