### PR TITLE
NXDOC-1292 - install Dart 1.23.x

### DIFF
--- a/src/corg/developer-environment-setup/installing-dart-and-related-tools.md
+++ b/src/corg/developer-environment-setup/installing-dart-and-related-tools.md
@@ -40,7 +40,7 @@ history:
 
 ---
 
-See <https://www.dartlang.org/install>
+See <https://www.dartlang.org/install>.
 
 ## Installing Dart
 
@@ -53,7 +53,7 @@ Pub 1.23.0
 
 ### Linux
 
-{{#> panel type='code' heading='Using APT'}}
+Using APT:
 
 ```bash
 sudo apt-get install apt-transport-https
@@ -67,39 +67,31 @@ sudo update-alternatives --install /usr/bin/pub pub /usr/lib/dart/bin/pub 0
 sudo update-alternatives --install /usr/bin/dart2js dart2js /usr/lib/dart/bin/dart2js 0
 ```
 
-{{/panel}}
-
 See https://www.dartlang.org/install/linux for other Linux install options.
 
 ### OS X
 
-{{#> panel type='code' heading='Using Homebrew'}}
+Using Homebrew:
 
 ```bash
 brew tap dart-lang/homebrew-dart
 brew install https://raw.githubusercontent.com/dart-lang/homebrew-dart/b55507ab62b2e724b62e58a8e5363a726e34b7e7/dart.rb --with-dartium
 ```
 
-{{/panel}}
-
 See https://www.dartlang.org/install/mac for other Mac install options.
 
 ### Windows
 
-{{#> panel type='code' heading='Using Chocolatey'}}
-
-See https://chocolatey.org/install to install Chocolatey, a package manager for Windows.
+Using [Chocolatey](https://chocolatey.org/install):
 
 ```bash
 choco install dart-sdk -version 1.23.0
 choco install dartium  -version 1.23.0
 ```
 
-{{/panel}}
-
 See https://www.dartlang.org/install/windows for other Windows install options.
 
 
-### Dart Tools
+## Dart Tools
 
-Dart plugins exist for many commonly used IDEs. See <https://www.dartlang.org/tools>
+Dart plugins exist for many commonly used IDEs. See <https://www.dartlang.org/tools>.

--- a/src/corg/developer-environment-setup/installing-dart-and-related-tools.md
+++ b/src/corg/developer-environment-setup/installing-dart-and-related-tools.md
@@ -44,16 +44,23 @@ See <https://www.dartlang.org/install>
 
 ## Installing Dart
 
+Modules based on Dart require the version 1.23.x. Once installed, verify the version in a terminal:
+
+```
+$ pub version
+Pub 1.23.0
+```
+
 ### Linux
 
-{{#> panel type='code' heading='Manual install of Dart'}}
+{{#> panel type='code' heading='Using APT'}}
 
 ```bash
 sudo apt-get install apt-transport-https
 sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
 sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
 sudo apt-get update
-sudo apt-get install dart
+sudo apt-get install dart=1.23.0-1
 
 sudo update-alternatives --install /usr/bin/dart dart /usr/lib/dart/bin/dart 0
 sudo update-alternatives --install /usr/bin/pub pub /usr/lib/dart/bin/pub 0
@@ -62,16 +69,36 @@ sudo update-alternatives --install /usr/bin/dart2js dart2js /usr/lib/dart/bin/da
 
 {{/panel}}
 
+See https://www.dartlang.org/install/linux for other Linux install options.
+
 ### OS X
 
 {{#> panel type='code' heading='Using Homebrew'}}
 
 ```bash
-brew tap dart-lang/dart
-brew install dart --with-dartium
+brew tap dart-lang/homebrew-dart
+brew install https://raw.githubusercontent.com/dart-lang/homebrew-dart/b55507ab62b2e724b62e58a8e5363a726e34b7e7/dart.rb --with-dartium
 ```
 
 {{/panel}}
+
+See https://www.dartlang.org/install/mac for other Mac install options.
+
+### Windows
+
+{{#> panel type='code' heading='Using Chocolatey'}}
+
+See https://chocolatey.org/install to install Chocolatey, a package manager for Windows.
+
+```bash
+choco install dart-sdk -version 1.23.0
+choco install dartium  -version 1.23.0
+```
+
+{{/panel}}
+
+See https://www.dartlang.org/install/windows for other Windows install options.
+
 
 ### Dart Tools
 


### PR DESCRIPTION
nuxeo-api-playground requires Dart 1.23.0, build fails with Dart >1.24