### PR TITLE
NXDOC-1307: Adds Safari as supported browser for WebUI

### DIFF
--- a/src/nxdoc/web-ui/web-ui-overview.md
+++ b/src/nxdoc/web-ui/web-ui-overview.md
@@ -127,6 +127,7 @@ Supported browsers for Nuxeo Web UI and Nuxeo Web UI Elements are:
 {{! multiexcerpt name='webui-supported-browsers'}}
  - Google Chrome
  - Firefox
+ - Safari
  - Edge
  - Internet Explorer 11
 {{! /multiexcerpt}}


### PR DESCRIPTION
Safari was missing. Added it.