### PR TITLE
Update Google vision configuration parameters info

### DIFF
--- a/src/nxdoc/nuxeo-add-ons/nuxeo-vision.md
+++ b/src/nxdoc/nuxeo-add-ons/nuxeo-vision.md
@@ -139,10 +139,14 @@ To install the Nuxeo Vision Package, you have several options:
 ### Google Vision Configuration
 - Configure a [Google service account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount)
 - As of march 2<sup>nd</sup>, 2016, billing must be activated in your google account in order to use the Vision API
-- Generate your credential key
-- Edit nuxeo.conf and add your service account credential key
+- You can generate either an API Key or a Service Account Key (saved as a JSON file)
+- If you created a Service Account Key, install it on your server and edit nuxeo.conf to add the full path to the file:
 ```
-org.nuxeo.vision.google.credential=[key_goes_here]
+org.nuxeo.vision.google.credential=[path_to_credentials_goes_here]
+```
+- If you generated an API key, use the `org.nuxeo.vision.google.key` parameter:
+```
+org.nuxeo.vision.google.key=[your_api_key_goes_here]
 ```
 
 See [https://cloud.google.com/vision/](https://cloud.google.com/vision/) for more information.


### PR DESCRIPTION
The plug-in accepts the two different authentication means provided by Google (and using the API key is easier: No need to install a file on your server)