### PR TITLE
Update docker package name on Linux (ubuntu)

### DIFF
--- a/src/nxdoc/nuxeo-server/installation/installing-and-setting-up-related-software.md
+++ b/src/nxdoc/nuxeo-server/installation/installing-and-setting-up-related-software.md
@@ -625,7 +625,7 @@ To generate a package (by default for the latest Ubuntu LTS) issue the following
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get install docker
+$ sudo apt-get install docker.io
 $ cd /tmp
 $ git clone https://github.com/nuxeo/nuxeo-tools-docker.git
 $ cd nuxeo-tools-docker/ccextractor


### PR DESCRIPTION
Update docker package name on Linux (ubuntu) using on CCExtractor Installation description:
   sudo apt install docker.io