### PR TITLE
Add @enabled attribute to command line contribution

### DIFF
--- a/src/nxdoc/nuxeo-server/additional-services/conversion/how-to-contribute-a-command-line-converter.md
+++ b/src/nxdoc/nuxeo-server/additional-services/conversion/how-to-contribute-a-command-line-converter.md
@@ -54,7 +54,7 @@ Add a new command line called&nbsp;`changeFormat` that changes the image format.
 ```xml
 <extension target="org.nuxeo.ecm.platform.commandline.executor.service.CommandLineExecutorComponent"
   point="command">
-  <command name="changeFormat">
+  <command name="changeFormat" enabled="true">
     <commandLine>convert</commandLine>
     <parameterString>#{sourceFilePath} #{targetFilePath}.#{format}
     </parameterString>


### PR DESCRIPTION
The CommandLineDescriptor requires @enabled to be set to true to be activated within Nuxeo.  When using the example out of the box, the server will fail with 'command not found/enabled. https://github.com/nuxeo/nuxeo/blob/master/nuxeo-core/nuxeo-platform-commandline-executor/src/main/java/org/nuxeo/ecm/platform/commandline/executor/service/CommandLineDescriptor.java