### PR TITLE
Fixed spelling of Mozilla

### DIFF
--- a/src/userdoc/jsf-ui/browsing-content/preview.md
+++ b/src/userdoc/jsf-ui/browsing-content/preview.md
@@ -212,7 +212,7 @@ history:
 {{! multiexcerpt name='preview_functional_overview'}}
 The preview enables you to see an insight of your document.
 
-The PDF files preview is leveraged by [pdf.js by Mozzilla](https://mozilla.github.io/pdf.js/). The preview of other file types are leveraged by the [Nuxeo Platform preview module]({{page space='nxdoc' page='preview'}}).
+The PDF files preview is leveraged by [pdf.js by Mozilla](https://mozilla.github.io/pdf.js/). The preview of other file types are leveraged by the [Nuxeo Platform preview module]({{page space='nxdoc' page='preview'}}).
 
 Several means to preview documents are available.
 


### PR DESCRIPTION
Changed "Mozzilla" to "Mozilla"