### PR TITLE
Starting in MongoDB 3.2 WiredTiger is the default storage engine

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
+++ b/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
@@ -235,8 +235,8 @@ Nuxeo supports the following MongoDB version:
 
 ## Installation
 
-When using MongoDB 3.0 or higher the [WiredTiger storage engine](https://docs.mongodb.org/manual/core/wiredtiger/) is the default storage engine for better performance of write operations.</br>
-Please follow [this documentation](https://docs.mongodb.org/manual/tutorial/change-standalone-wiredtiger/) to activate this storage engine.
+When using MongoDB 3.2 or higher the [WiredTiger storage engine](https://docs.mongodb.org/manual/core/wiredtiger/) is the default storage engine.</br>
+Please follow [this documentation](https://docs.mongodb.org/manual/tutorial/change-standalone-wiredtiger/) if you’re running on MongoDB 3.0 to activate this storage engine for better performance of write operations.
 
 Nuxeo stores its data in a MongoDB database under the `default` collection. The name of the collection is the Nuxeo repository name. If you have more than one repository configured, other collections with the names of these repositories will be used for storage.
 

--- a/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
+++ b/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
@@ -235,12 +235,8 @@ Nuxeo supports the following MongoDB version:
 
 ## Installation
 
-When using MongoDB 3.0 or higher we recommend that you configure the [WiredTiger storage engine](https://docs.mongodb.org/manual/core/wiredtiger/) for better performance of write operations. Please follow [this documentation](https://docs.mongodb.org/manual/tutorial/change-standalone-wiredtiger/) to activate this storage engine.
-
-{{#> callout type='info' }}
-Starting in MongoDB 3.2, the WiredTiger storage engine is the default storage engine.
-{{/callout}}
-
+When using MongoDB 3.0 or higher the [WiredTiger storage engine](https://docs.mongodb.org/manual/core/wiredtiger/) is the default storage engine for better performance of write operations.</br>
+Please follow [this documentation](https://docs.mongodb.org/manual/tutorial/change-standalone-wiredtiger/) to activate this storage engine.
 
 Nuxeo stores its data in a MongoDB database under the `default` collection. The name of the collection is the Nuxeo repository name. If you have more than one repository configured, other collections with the names of these repositories will be used for storage.
 

--- a/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
+++ b/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
@@ -237,6 +237,11 @@ Nuxeo supports the following MongoDB version:
 
 When using MongoDB 3.0 or higher we recommend that you configure the [WiredTiger storage engine](https://docs.mongodb.org/manual/core/wiredtiger/) for better performance of write operations. Please follow [this documentation](https://docs.mongodb.org/manual/tutorial/change-standalone-wiredtiger/) to activate this storage engine.
 
+{{#> callout type='info' }}
+Starting in MongoDB 3.2, the WiredTiger storage engine is the default storage engine.
+{{/callout}}
+
+
 Nuxeo stores its data in a MongoDB database under the `default` collection. The name of the collection is the Nuxeo repository name. If you have more than one repository configured, other collections with the names of these repositories will be used for storage.
 
 By default MongoDB doesn't require authentication, but you can [enable the client access control](https://docs.mongodb.org/manual/tutorial/enable-authentication/) and create a user with the `dbOwner` role.


### PR DESCRIPTION
Starting in MongoDB 3.2, the WiredTiger storage engine is the default storage engine.