### PR TITLE
NXP-26072/NXP-26074: TLS/SSL connection

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
+++ b/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
@@ -283,6 +283,23 @@ See the [MongoDB Connection String URI Format](http://docs.mongodb.org/manual/re
 
 {{/callout}}
 
+#### TLS/SSL configuration
+
+If you have chosen to configure TLS/SSL then you can set up Nuxeo using `nuxeo.conf` with the following properties (since Nuxeo 9.10-HF22):
+
+```
+nuxeo.mongodb.ssl=true
+nuxeo.mongodb.truststore.path
+nuxeo.mongodb.truststore.password
+nuxeo.mongodb.truststore.type
+nuxeo.mongodb.keystore.path
+nuxeo.mongodb.keystore.password
+nuxeo.mongodb.keystore.type
+```
+
+See the [Trust Store and Key Store Configuration]({{page page='trust-store-and-key-store-configuration'}}) page for more.
+
+
 ## GridFS
 
 It is possible to use MongoDB's [GridFS](https://docs.mongodb.org/manual/core/gridfs/) mechanism to store binary files inside MongoDB instead of the default filesystem mechanism of Nuxeo. This is activated by adding `gridfsbinaries` to the templates, for instance:

--- a/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
+++ b/src/nxdoc/nuxeo-server/administration/database-configuration/mongodb.md
@@ -283,7 +283,7 @@ See the [MongoDB Connection String URI Format](http://docs.mongodb.org/manual/re
 
 {{/callout}}
 
-#### TLS/SSL configuration
+#### TLS/SSL Configuration
 
 If you have chosen to configure TLS/SSL then you can set up Nuxeo using `nuxeo.conf` with the following properties (since Nuxeo 9.10-HF22):
 

--- a/src/nxdoc/nuxeo-server/administration/elasticsearch-setup.md
+++ b/src/nxdoc/nuxeo-server/administration/elasticsearch-setup.md
@@ -597,19 +597,33 @@ curl -XPOST -u elastic 'localhost:9200/_xpack/security/user/nuxeo_user' -H "Cont
 }'
 ```
 {{/callout}}
-##### SSL/TLS configuration
-If you have chosen to configure [SSL/TLS](https://www.elastic.co/guide/en/x-pack/5.6/ssl-tls.html) then you can setup Nuxeo using `nuxeo.conf` with the following properties:
+##### TLS/SSL configuration
+If you have chosen to configure [TLS/SSL](https://www.elastic.co/guide/en/x-pack/5.6/ssl-tls.html) then you can set up Nuxeo using `nuxeo.conf` with the following properties (since Nuxeo 9.10-HF22):
 ```
-elasticsearch.restClient.keystorePath=your_path_to_keystore
-elasticsearch.restClient.keystorePassword=your_password
-elasticsearch.restClient.keystoreType=your_keystore_type
+elasticsearch.restClient.truststore.path
+elasticsearch.restClient.truststore.password
+elasticsearch.restClient.truststore.type
+elasticsearch.restClient.keystore.path
+elasticsearch.restClient.keystore.password
+elasticsearch.restClient.keystore.type
 ```
-- `keystoreType` is optional, if unspecified it uses the default Java system keystore type, e.g. jks
+
+In previous versions of Nuxeo 9.10, you had to use the following properties for the _Trust Store_ (despite their incorrect name):
+
+- `elasticsearch.restClient.keystorePath`
+- `elasticsearch.restClient.keystorePassword`
+- `elasticsearch.restClient.keystoreType`
+
+Before Nuxeo 9.10-HF22, it was not possible to configure the Key Store.
 
 {{#> callout type='warning' }}
 
-If you are using SSL then the `elasticsearch.addressList` will need to be updated to include the `https`.
+If you are using TLS/SSL then the `elasticsearch.addressList` will need to be updated to include `https`.
 {{/callout}}
+
+See the [Trust Store and Key Store Configuration]({{page page='trust-store-and-key-store-configuration'}}) page for more.
+
+
 ### Index names
 
 Nuxeo manages 3 Elasticsearch indexes:

--- a/src/nxdoc/nuxeo-server/administration/elasticsearch-setup.md
+++ b/src/nxdoc/nuxeo-server/administration/elasticsearch-setup.md
@@ -597,8 +597,10 @@ curl -XPOST -u elastic 'localhost:9200/_xpack/security/user/nuxeo_user' -H "Cont
 }'
 ```
 {{/callout}}
-##### TLS/SSL configuration
+##### TLS/SSL Configuration
+
 If you have chosen to configure [TLS/SSL](https://www.elastic.co/guide/en/x-pack/5.6/ssl-tls.html) then you can set up Nuxeo using `nuxeo.conf` with the following properties (since Nuxeo 9.10-HF22):
+
 ```
 elasticsearch.restClient.truststore.path
 elasticsearch.restClient.truststore.password

--- a/src/nxdoc/nuxeo-server/advanced-topics/trust-store-and-key-store-configuration.md
+++ b/src/nxdoc/nuxeo-server/advanced-topics/trust-store-and-key-store-configuration.md
@@ -154,7 +154,7 @@ See the [MongoDB Configuration]({{page page='mongodb'}}) page for more.
 
 ## Troubleshooting
 
-If your Nuxeo instance cannot access Nuxeo Online Services anymore, or the Marketplace and Hot Fixes are no longer automatically available (through the Update Center for instance), this can mean that the Trust Store does not contain the certificates from the authority that signed the Nuxeo Online Services certificates, which are normally part of the default JVM Trust Store.
+If your Nuxeo instance cannot access Nuxeo Online Services anymore, or the Marketplace and hotfixes are no longer automatically available (through the Update Center for instance), this can mean that the Trust Store does not contain the certificates from the authority that signed the Nuxeo Online Services certificates, which are normally part of the default JVM Trust Store.
 
 If you have the following error in your logs during the connection establishment:
 


### PR DESCRIPTION
Backport of master without the Redis changes (which have not been backported). Mentions that the changes are for Nuxeo >= 9.10-HF22
