### PR TITLE
NXDOC-1568: Update page How to Override Existing Document Types

### DIFF
--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -140,7 +140,7 @@ Necessary facets
 
 Additional comments
 
-</th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td>
+</th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable, NXTag</td><td colspan="1">Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
 
 </tr><tr><td colspan="1">
 
@@ -284,7 +284,7 @@ Orderable
 
 &nbsp;
 
-</td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+</td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td><td colspan="1">Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td></tr><tr><td colspan="1">
 
 Relation
 
@@ -346,7 +346,7 @@ PublishSpace, SuperSpace
 
 The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.
 
-</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td><td colspan="1">Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td></tr><tr><td colspan="1">
 
 Workspace
 
@@ -368,7 +368,7 @@ SuperSpace
 
 </td><td colspan="1">
 
-The SuperSpace facet is required for children documents to get default notifications configured in the 'Alerts' tab.
+The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.
 
 </td></tr><tr><td colspan="1">
 

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -142,7 +142,7 @@ Additional comments
 
 </th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Domain</td><td colspan="1">Domain</td><td colspan="1">Folder</td><td colspan="1">domain</td><td colspan="1">
 
-SuperSpace
+SuperSpace, NotCollectionMember
 
 </td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
 
@@ -158,7 +158,7 @@ Document
 
 </td><td colspan="1">
 
-file, files, common, dublincore
+file, files, common, dublincore, uid
 
 </td><td colspan="1">
 
@@ -182,7 +182,7 @@ Document
 
 </td><td colspan="1">
 
-&nbsp;
+common, dublincore
 
 </td><td colspan="1">
 
@@ -244,7 +244,7 @@ PublishSpace, SuperSpace
 
 The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.
 
-</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Thread</td><td colspan="1">Thread</td><td colspan="1">Document</td><td colspan="1">common, dublincore, thread</td><td colspan="1">Commentable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Thread</td><td colspan="1">Thread</td><td colspan="1">Document</td><td colspan="1">common, dublincore, thread</td><td colspan="1">Commentable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
 
 Workspace
 
@@ -286,7 +286,7 @@ Folder
 
 </td><td colspan="1">
 
-SuperSpace
+SuperSpace, HiddenInCreation, NotCollectionMember
 
 </td><td colspan="1">
 

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -2,8 +2,8 @@
 title: 'HOWTO: Override Existing Document Types'
 review:
   comment: ''
-  date: '2017-02-13'
-  status: not-ok
+  date: '2019-03-11'
+  status: ok
 details:
   howto:
     excerpt: Learn how to override an existing document type in Nuxeo Studio.

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -101,20 +101,22 @@ history:
 ---
 
 {{! excerpt}}
-
 Any built-in document type can be overridden: you just have to use the good ID, inherit the good type and add some necessary schemas and facets. We provide a table that should give you all necessary information.
-
 {{! /excerpt}}
 
 When inheriting from a document type, you inherit its schemas and facets. For instance, when inheriting from Document, you get the `dublincore` schema (that holds the title, description, modification date, ... metadata), as well as `common` (that holds the size of the doc) and `uid` (that holds version information and ID).
 
 {{#> callout type='note' heading='Deployment Mode'}}
-
-Be careful to select the **Override** deployment mode from the **Advanced Configuration** section on the **Definition** tab of your document type. Should you leave **Merge**, you would get both your customizations and the default behavior of the document type instead of only your own customizations.
-
+Be careful to select the **Override** deployment mode from the **Advanced Configuration** section on the **Definition** tab of your document type in Nuxeo Studio. If you leave the **Merge** mode, you would get both your customizations and the default behavior of the document type instead of only your own customizations.
+{{!--     ### nx_asset ###
+    path: /default-domain/workspaces/Product Management/Documentation/Documentation Screenshots/NXDOC/Master/HOWTO: Override Existing Document Types/Override Mode in Studio
+    name: STUDIO-override-mode.png
+    studio_modeler#screenshot#up_to_date
+--}}
+![Override Mode in Studio](nx_asset://af70e650-bad0-4fbc-a718-aab947d1d67d ?w=250,border=true)
 {{/callout}}
 
-Below are the document types provided by the default Nuxeo Platform, the Document Management and Digital Asset Management modules. Don't hesitate to give feedback if you encounter troubles.
+Below are the document types provided by the default Nuxeo Platform, the Document Management and Digital Asset Management modules.
 
 <div class="table-scroll">
   <table class="hover">
@@ -276,16 +278,14 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
 </div>
 
 {{#> callout type='info' }}
-
-The Alert tab is currently only available on JSF UI. It is planned to be integrated in Nuxeo Web UI.
-
+The Alert tab is currently only available on JSF UI, which is deprecated since Nuxeo Platform LTS 2019 (10.10). It is planned to be integrated in Nuxeo Web UI.
 {{/callout}}
 
 {{#> callout type='tip' }}
-
 You can also browse the [contributions to the Type extension](http://explorer.nuxeo.org/nuxeo/site/distribution/current/viewExtensionPoint/org.nuxeo.ecm.core.schema.TypeService--doctype) for more document types.
-
 {{/callout}}
+
+---
 
 <div class="row" data-equalizer data-equalize-on="medium">
 <div class="column medium-6">

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -116,287 +116,164 @@ Be careful to select the **Override** deployment mode from the **Advanced Config
 
 Below are the document types provided by the default Nuxeo Platform, the Document Management and Digital Asset Management modules. Don't hesitate to give feedback if you encounter troubles.
 
-<div class="table-scroll"><table class="hover"><tbody><tr><th colspan="1">
-
-Document type label
-
-</th><th colspan="1">
-
-Document type ID
-
-</th><th colspan="1">
-
-Inherits from
-
-</th><th colspan="1">
-
-Necessary schemas
-
-</th><th colspan="1">
-
-Necessary facets
-
-</th><th colspan="1">
-
-Additional comments
-
-</th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable, NXTag</td><td colspan="1">Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
-
-</tr><tr><td colspan="1">
-
-Collection
-
-</td><td colspan="1">
-
-Collection
-
-</td><td colspan="1">
-
-Document
-
-</td><td colspan="1">
-
-uid, dublincore, common
-
-</td><td colspan="1">
-
-Versionable, Collection, NotCollectionMember
-
-</td><td colspan="1">
-
-</td></tr><tr><td colspan="1">
-
-Collections
-
-</td><td colspan="1">
-
-Collections
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-</td><td colspan="1">
-
-NotCollectionMember
-
-</td><td colspan="1">
-
-</td></tr><tr><td colspan="1">Domain</td><td colspan="1">Domain</td><td colspan="1">Folder</td><td colspan="1">domain</td><td colspan="1">
-
-SuperSpace, NotCollectionMember
-
-</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
-
-File
-
-</td><td colspan="1">
-
-File
-
-</td><td colspan="1">
-
-Document
-
-</td><td colspan="1">
-
-file, files, common, dublincore, uid
-
-</td><td colspan="1">
-
-Commentable, Downloadable,&nbsp;HasRelatedText,&nbsp; Publishable, Versionable
-
-</td><td colspan="1">
-
-&nbsp;
-
-</td></tr><tr><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-Document
-
-</td><td colspan="1">
-
-common, dublincore
-
-</td><td colspan="1">
-
-Folderish
-
-</td><td colspan="1">
-
-&nbsp;
-
-</td></tr><tr><td colspan="1">
-
-HiddenFolder
-
-</td><td colspan="1">
-
-HiddenFolder
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-</td><td colspan="1">
-
-HiddenInNavigation
-
-</td><td colspan="1">
-
-</td></tr><tr><td colspan="1">Note</td><td colspan="1">Note</td><td colspan="1">Document</td><td colspan="1">common, dublincore, files, note, uid</td><td colspan="1">
-
-Commentable, HasRelatedText, Publishable, Versionable
-
-</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
-
-OrderedFolder
-
-</td><td colspan="1">
-
-OrderedFolder
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-&nbsp;
-
-</td><td colspan="1">
-
-Orderable
-
-</td><td colspan="1">
-
-&nbsp;
-
-</td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td><td colspan="1">Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td></tr><tr><td colspan="1">
-
-Relation
-
-</td><td colspan="1">
-
-Relation
-
-</td><td colspan="1">
-
-</td><td colspan="1">
-
-relation, dublincore
-
-</td><td colspan="1">
-
-</td><td colspan="1">
-
-</td></tr><tr><td colspan="1">
-
-Root
-
-</td><td colspan="1">
-
-Root
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-</td><td colspan="1">
-
-NotCollectionMember
-
-</td><td colspan="1">
-
-</td></tr><tr><td colspan="1">
-
-Section
-
-</td><td colspan="1">
-
-Section
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-file
-
-</td><td colspan="1">
-
-PublishSpace, SuperSpace
-
-</td><td colspan="1">
-
-The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.
-
-</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td><td colspan="1">Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td></tr><tr><td colspan="1">
-
-Workspace
-
-</td><td colspan="1">
-
-Workspace
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-webcontainer, publishing, file, files
-
-</td><td colspan="1">
-
-SuperSpace
-
-</td><td colspan="1">
-
-The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.
-
-</td></tr><tr><td colspan="1">
-
-WorkspaceRoot
-
-</td><td colspan="1">
-
-WorkspaceRoot
-
-</td><td colspan="1">
-
-Folder
-
-</td><td colspan="1">
-
-&nbsp;
-
-</td><td colspan="1">
-
-SuperSpace, HiddenInCreation, NotCollectionMember
-
-</td><td colspan="1">
-
-&nbsp;
-
-</td>
-
-</tr></tbody></table></div>
+<div class="table-scroll">
+  <table class="hover">
+    <tbody>
+      <tr>
+        <th>Document type label</th>
+        <th>Document type ID</th>
+        <th>Inherits from</th>
+        <th>Necessary schemas</th>
+        <th>Necessary facets</th>
+        <th>Additional comments</th>
+      </tr>
+      <tr>
+        <td>Audio</td>
+        <td>Audio</td>
+        <td>Document</td>
+        <td>common, dublincore, uid</td>
+        <td>Audio, Commentable, Publishable, Versionable, NXTag</td>
+        <td>Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
+      </tr>
+      <tr>
+        <td>Collection</td>
+        <td>Collection</td>
+        <td>Document</td>
+        <td>uid, dublincore, common</td>
+        <td>Versionable, Collection, NotCollectionMember</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Collections</td>
+        <td>Collections</td>
+        <td>Folder</td>
+        <td></td>
+        <td>NotCollectionMember</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Domain</td>
+        <td>Domain</td>
+        <td>Folder</td>
+        <td>domain</td>
+        <td>SuperSpace, NotCollectionMember</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>File</td>
+        <td>File</td>
+        <td>Document</td>
+        <td>file, files, common, dublincore, uid</td>
+        <td>Commentable, Downloadable,&nbsp;HasRelatedText,&nbsp; Publishable, Versionable</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Folder</td>
+        <td>Folder</td>
+        <td>Document</td>
+        <td>common, dublincore</td>
+        <td>Folderish</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>HiddenFolder</td>
+        <td>HiddenFolder</td>
+        <td>Folder</td>
+        <td></td>
+        <td>HiddenInNavigation</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Note</td>
+        <td>Note</td>
+        <td>Document</td>
+        <td>common, dublincore, files, note, uid</td>
+        <td>Commentable, HasRelatedText, Publishable, Versionable</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>OrderedFolder</td>
+        <td>OrderedFolder</td>
+        <td>Folder</td>
+        <td></td>
+        <td>Orderable</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Picture</td>
+        <td>Picture</td>
+        <td>Document</td>
+        <td>common, dublincore, uid</td>
+        <td>Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td>
+        <td>Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
+      </tr>
+      <tr>
+        <td>Relation</td>
+        <td>Relation</td>
+        <td></td>
+        <td>relation, dublincore</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Root</td>
+        <td>Root</td>
+        <td>Folder</td>
+        <td></td>
+        <td>NotCollectionMember</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Section</td>
+        <td>Section</td>
+        <td>Folder</td>
+        <td>file</td>
+        <td>PublishSpace, SuperSpace</td>
+        <td>The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.</td>
+      </tr>
+      <tr>
+        <td>SectionRoot</td>
+        <td>SectionRoot</td>
+        <td>Folder</td>
+        <td></td>
+        <td>MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>TemplateRoot</td>
+        <td>TemplateRoot</td>
+        <td>Folder</td>
+        <td></td>
+        <td>SuperSpace, HiddenInCreation, NotCollectionMember</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Video</td>
+        <td>Video</td>
+        <td>Document</td>
+        <td>common, dublincore, uid, files</td>
+        <td>Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td>
+        <td>Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
+      </tr>
+      <tr>
+        <td>Workspace</td>
+        <td>Workspace</td>
+        <td>Folder</td>
+        <td>webcontainer, publishing, file, files</td>
+        <td>SuperSpace</td>
+        <td>The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.</td>
+      </tr>
+      <tr>
+        <td>WorkspaceRoot</td>
+        <td>WorkspaceRoot</td>
+        <td>Folder</td>
+        <td></td>
+        <td>SuperSpace, HiddenInCreation, NotCollectionMember</td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 {{#> callout type='info' }}
 

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -140,7 +140,7 @@ Necessary facets
 
 Additional comments
 
-</th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Domain</td><td colspan="1">Domain</td><td colspan="1">Folder</td><td colspan="1">domain</td><td colspan="1">
+</th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Domain</td><td colspan="1">Domain</td><td colspan="1">Folder</td><td colspan="1">domain</td><td colspan="1">
 
 SuperSpace, NotCollectionMember
 
@@ -220,7 +220,7 @@ Orderable
 
 &nbsp;
 
-</td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Post</td><td colspan="1">Post</td><td colspan="1">Document</td><td colspan="1">common, dublincore, post</td><td colspan="1">Commentable, HiddenInNavigation</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+</td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Post</td><td colspan="1">Post</td><td colspan="1">Document</td><td colspan="1">common, dublincore, post</td><td colspan="1">Commentable, HiddenInNavigation</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
 
 Section
 
@@ -244,7 +244,7 @@ PublishSpace, SuperSpace
 
 The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.
 
-</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Thread</td><td colspan="1">Thread</td><td colspan="1">Document</td><td colspan="1">common, dublincore, thread</td><td colspan="1">Commentable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Thread</td><td colspan="1">Thread</td><td colspan="1">Document</td><td colspan="1">common, dublincore, thread</td><td colspan="1">Commentable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
 
 Workspace
 

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -140,7 +140,51 @@ Necessary facets
 
 Additional comments
 
-</th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Domain</td><td colspan="1">Domain</td><td colspan="1">Folder</td><td colspan="1">domain</td><td colspan="1">
+</th></tr><tr><td colspan="1">Audio</td><td colspan="1">Audio</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Audio, Commentable, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td>
+
+</tr><tr><td colspan="1">
+
+Collection
+
+</td><td colspan="1">
+
+Collection
+
+</td><td colspan="1">
+
+Document
+
+</td><td colspan="1">
+
+uid, dublincore, common
+
+</td><td colspan="1">
+
+Versionable, Collection, NotCollectionMember
+
+</td><td colspan="1">
+
+</td></tr><tr><td colspan="1">
+
+Collections
+
+</td><td colspan="1">
+
+Collections
+
+</td><td colspan="1">
+
+Folder
+
+</td><td colspan="1">
+
+</td><td colspan="1">
+
+NotCollectionMember
+
+</td><td colspan="1">
+
+</td></tr><tr><td colspan="1">Domain</td><td colspan="1">Domain</td><td colspan="1">Folder</td><td colspan="1">domain</td><td colspan="1">
 
 SuperSpace, NotCollectionMember
 
@@ -192,6 +236,26 @@ Folderish
 
 &nbsp;
 
+</td></tr><tr><td colspan="1">
+
+HiddenFolder
+
+</td><td colspan="1">
+
+HiddenFolder
+
+</td><td colspan="1">
+
+Folder
+
+</td><td colspan="1">
+
+</td><td colspan="1">
+
+HiddenInNavigation
+
+</td><td colspan="1">
+
 </td></tr><tr><td colspan="1">Note</td><td colspan="1">Note</td><td colspan="1">Document</td><td colspan="1">common, dublincore, files, note, uid</td><td colspan="1">
 
 Commentable, HasRelatedText, Publishable, Versionable
@@ -221,6 +285,44 @@ Orderable
 &nbsp;
 
 </td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+
+Relation
+
+</td><td colspan="1">
+
+Relation
+
+</td><td colspan="1">
+
+</td><td colspan="1">
+
+relation, dublincore
+
+</td><td colspan="1">
+
+</td><td colspan="1">
+
+</td></tr><tr><td colspan="1">
+
+Root
+
+</td><td colspan="1">
+
+Root
+
+</td><td colspan="1">
+
+Folder
+
+</td><td colspan="1">
+
+</td><td colspan="1">
+
+NotCollectionMember
+
+</td><td colspan="1">
+
+</td></tr><tr><td colspan="1">
 
 Section
 

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -192,7 +192,7 @@ Folderish
 
 &nbsp;
 
-</td></tr><tr><td colspan="1">Forum</td><td colspan="1">Forum</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">&nbsp;</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Note</td><td colspan="1">Note</td><td colspan="1">Document</td><td colspan="1">common, dublincore, files, note, uid</td><td colspan="1">
+</td></tr><tr><td colspan="1">Note</td><td colspan="1">Note</td><td colspan="1">Document</td><td colspan="1">common, dublincore, files, note, uid</td><td colspan="1">
 
 Commentable, HasRelatedText, Publishable, Versionable
 
@@ -220,7 +220,7 @@ Orderable
 
 &nbsp;
 
-</td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Post</td><td colspan="1">Post</td><td colspan="1">Document</td><td colspan="1">common, dublincore, post</td><td colspan="1">Commentable, HiddenInNavigation</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+</td></tr><tr><td colspan="1">Picture</td><td colspan="1">Picture</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid</td><td colspan="1">Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
 
 Section
 
@@ -244,7 +244,7 @@ PublishSpace, SuperSpace
 
 The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.
 
-</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Thread</td><td colspan="1">Thread</td><td colspan="1">Document</td><td colspan="1">common, dublincore, thread</td><td colspan="1">Commentable</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
+</td></tr><tr><td colspan="1">SectionRoot</td><td colspan="1">SectionRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">TemplateRoot</td><td colspan="1">TemplateRoot</td><td colspan="1">Folder</td><td colspan="1">&nbsp;</td><td colspan="1">SuperSpace, HiddenInCreation, NotCollectionMember</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">Video</td><td colspan="1">Video</td><td colspan="1">Document</td><td colspan="1">common, dublincore, uid, files</td><td colspan="1">Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td><td colspan="1">&nbsp;</td></tr><tr><td colspan="1">
 
 Workspace
 

--- a/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
+++ b/src/nxdoc/nuxeo-server/core-server/content-repository/content-repository-tutorials/how-to-override-existing-document-types.md
@@ -132,15 +132,15 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
         <td>Audio</td>
         <td>Document</td>
         <td>common, dublincore, uid</td>
-        <td>Audio, Commentable, Publishable, Versionable, NXTag</td>
+        <td>Audio, Commentable, NXTag, Publishable, Versionable</td>
         <td>Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
       </tr>
       <tr>
         <td>Collection</td>
         <td>Collection</td>
         <td>Document</td>
-        <td>uid, dublincore, common</td>
-        <td>Versionable, Collection, NotCollectionMember</td>
+        <td>common, dublincore, uid</td>
+        <td>Collection, NotCollectionMember, Versionable</td>
         <td></td>
       </tr>
       <tr>
@@ -156,15 +156,15 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
         <td>Domain</td>
         <td>Folder</td>
         <td>domain</td>
-        <td>SuperSpace, NotCollectionMember</td>
+        <td>NotCollectionMember, SuperSpace</td>
         <td></td>
       </tr>
       <tr>
         <td>File</td>
         <td>File</td>
         <td>Document</td>
-        <td>file, files, common, dublincore, uid</td>
-        <td>Commentable, Downloadable,&nbsp;HasRelatedText,&nbsp; Publishable, Versionable</td>
+        <td>common, dublincore, file, files, uid</td>
+        <td>Commentable, Downloadable, HasRelatedText, Publishable, Versionable</td>
         <td></td>
       </tr>
       <tr>
@@ -204,14 +204,14 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
         <td>Picture</td>
         <td>Document</td>
         <td>common, dublincore, uid</td>
-        <td>Commentable, HasRelatedText, Picture, Publishable, Versionable, NXTag</td>
+        <td>Commentable, HasRelatedText, NXTag, Picture, Publishable, Versionable</td>
         <td>Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
       </tr>
       <tr>
         <td>Relation</td>
         <td>Relation</td>
         <td></td>
-        <td>relation, dublincore</td>
+        <td>dublincore, relation</td>
         <td></td>
         <td></td>
       </tr>
@@ -236,7 +236,7 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
         <td>SectionRoot</td>
         <td>Folder</td>
         <td></td>
-        <td>MasterPublishSpace, SuperSpace, HiddenInCreation, NotCollectionMember</td>
+        <td>HiddenInCreation, MasterPublishSpace, NotCollectionMember, SuperSpace</td>
         <td></td>
       </tr>
       <tr>
@@ -244,7 +244,7 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
         <td>TemplateRoot</td>
         <td>Folder</td>
         <td></td>
-        <td>SuperSpace, HiddenInCreation, NotCollectionMember</td>
+        <td>HiddenInCreation, NotCollectionMember, SuperSpace</td>
         <td></td>
       </tr>
       <tr>
@@ -252,14 +252,14 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
         <td>Video</td>
         <td>Document</td>
         <td>common, dublincore, uid, files</td>
-        <td>Commentable, Publishable, Versionable, Video, HasStoryboard, HasVideoPreview, NXTag</td>
+        <td>Commentable, HasStoryboard, HasVideoPreview, NXTag, Publishable, Versionable, Video</td>
         <td>Available when using the [DAM addon]({{page page='digital-asset-management-dam'}}).</td>
       </tr>
       <tr>
         <td>Workspace</td>
         <td>Workspace</td>
         <td>Folder</td>
-        <td>webcontainer, publishing, file, files</td>
+        <td>file, files, publishing, webcontainer</td>
         <td>SuperSpace</td>
         <td>The SuperSpace facet is required for children documents to get default notifications configured in the **Alerts** tab.</td>
       </tr>
@@ -268,7 +268,7 @@ Below are the document types provided by the default Nuxeo Platform, the Documen
         <td>WorkspaceRoot</td>
         <td>Folder</td>
         <td></td>
-        <td>SuperSpace, HiddenInCreation, NotCollectionMember</td>
+        <td>HiddenInCreation, NotCollectionMember, SuperSpace</td>
         <td></td>
       </tr>
     </tbody>


### PR DESCRIPTION
Split into many commits, to isolate the different steps.
- Updated the info on the existing document types (core and DAM).
- Removed outdated document types: Thread, Post and Forum.
- Added new document types: Collection, Collections, HiddenFolder, Root and Relation.
- Added links to the DAM addon page for Audio, Picture and Video.
- Proposed improvement: cleanup the table by formatting it properly.

Based on the following sources for the document type info update:
- [Core document types](https://github.com/nuxeo/nuxeo/blob/a3ff6b1/nuxeo-core/nuxeo-core/src/main/resources/OSGI-INF/CoreExtensions.xml).
- [Audio document type](https://github.com/nuxeo/nuxeo-platform-audio/blob/e820a51/nuxeo-platform-audio-core/src/main/resources/OSGI-INF/core-types-contrib.xml).
- [Picture document type](https://github.com/nuxeo/nuxeo/blob/7459379/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/resources/OSGI-INF/picture-schemas-contrib.xml).
- [Video document type](https://github.com/nuxeo/nuxeo-platform-video/blob/6a2ba2b/nuxeo-platform-video-core/src/main/resources/OSGI-INF/core-types-contrib.xml).