### PR TITLE
NXDRIVE-1611: Add new options related to chunk uploads

### DIFF
--- a/src/client-apps/nuxeo-drive.md
+++ b/src/client-apps/nuxeo-drive.md
@@ -824,7 +824,7 @@ Metadata Edit allows you to edit the metadata of your document from your desktop
 2. Right-click on the name of the document that you want to edit.
 3. Click on Nuxeo Drive > Edit metadata.
     A view or a browser page is then opened to the document metadata.
-    ![]({{file name='Drive_metadata_view.png' page='nuxeo-drive'}} ?w=350)
+    ![]({{file name='drive-metadata-view.png' page='nuxeo-drive'}} ?w=350)
 4. Click on **Edit** and modify your document,
     ![]({{file name='drive-metadata-edit.png' page='nuxeo-drive'}} ?w=350)
 5. Click on **Save**.

--- a/src/client-apps/nuxeo-drive/nuxeo-drive-installation-configuration.md
+++ b/src/client-apps/nuxeo-drive/nuxeo-drive-installation-configuration.md
@@ -247,6 +247,9 @@ Parameter values are taken as is, except for booleans. In that case, you can spe
 | Parameter | Default Value | Type | Description
 |---|---|---|---
 | `ca-bundle` | None | str | File or directory with certificates of trusted CAs. If set, `ssl-no-verify` has no effect. See the `requests` [documentation](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification) for more details.
+| `chunk_limit` | 20 | int | Size in Mio above which files will be uploaded in chunks (if `chunk_upload` is `True`). Has to be above 0.
+| `chunk_size` | 20 | int | Size of the chunks in Mio. Has to be above 0 and lower or equal to 20.
+| `chunk_upload` | True | bool | Activate the upload in chunks for files bigger than `chunk_limit`.
 | `debug` | False | bool | Activate the debug window, and debug mode.
 | `delay` | 30 | int | Define the delay before each remote check.
 | `force-locale` | None | str | Force the reset to the language.


### PR DESCRIPTION
Also:
* Fixed `drive-metadata-view.png` link in "Editing Metadata".

To be merged when Drive 4.1.1 is out. I will ping this PR when OK :)