### PR TITLE
Normalize Studio How To Page Titles

### DIFF
--- a/src/studio/nuxeo-studio/tutorials/eclipse-export.md
+++ b/src/studio/nuxeo-studio/tutorials/eclipse-export.md
@@ -1,5 +1,5 @@
 ---
-title: 'Is it Possible to Export a Studio Project in Eclipse?'
+title: 'HOWTO: Export a Studio Project in Eclipse'
 description: Discover what we recommend instead of exporting your Studio Project in Eclipse.
 review:
   comment: ''

--- a/src/studio/nuxeo-studio/tutorials/how-to-enable-package-specific-features-in-studio-for-dam-or-virtual-navigation.md
+++ b/src/studio/nuxeo-studio/tutorials/how-to-enable-package-specific-features-in-studio-for-dam-or-virtual-navigation.md
@@ -1,5 +1,5 @@
 ---
-title: 'How to Enable Package Specific Features in Studio for DAM or Virtual
+title: 'HOWTO: Enable Package Specific Features in Studio for DAM or Virtual
     Navigation?'
 review:
     comment: ''

--- a/src/studio/nuxeo-studio/tutorials/maven-integration.md
+++ b/src/studio/nuxeo-studio/tutorials/maven-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Maven Integration
+title: 'HOWTO: Work with Maven Integration'
 review:
     comment: ''
     date: '2018-03-29'

--- a/src/studio/nuxeo-studio/tutorials/referencing-an-externally-defined-operation.md
+++ b/src/studio/nuxeo-studio/tutorials/referencing-an-externally-defined-operation.md
@@ -1,5 +1,5 @@
 ---
-title: Referencing an Externally Defined Operation
+title: 'HOWTO: Reference an External Operation'
 review:
     comment: ''
     date: ''

--- a/src/studio/nuxeo-studio/tutorials/referencing-an-externally-defined-type.md
+++ b/src/studio/nuxeo-studio/tutorials/referencing-an-externally-defined-type.md
@@ -1,5 +1,5 @@
 ---
-title: Referencing an Externally Defined Type
+title: 'HOWTO: Reference an External Document Type'
 review:
     comment: ''
     date: ''


### PR DESCRIPTION
Since the new Studio header page in 3.21.0 will contain a link to Nuxeo Studio tutorials, we need to clean the current How To listing in https://doc.nuxeo.com/studio/tutorials/. 