### PR TITLE
NXDOC-2002: streamStatus probe enable by default on health check

### DIFF
--- a/src/nxdoc/nuxeo-server/events-and-messages/nuxeo-stream.md
+++ b/src/nxdoc/nuxeo-server/events-and-messages/nuxeo-stream.md
@@ -240,6 +240,15 @@ The above configuration defines a retry policy with 8 retries, starting with a d
 
 This policy tolerates a ~4min shortage.
 
+Note that the default policy in Nuxeo is:
+```xml
+<policy name="..." maxRetries="20" delay="1s" maxDelay="60s" continueOnFailure="false" />
+```
+which tolerates a 15min shortage.
+
+When using Kafka, the record is reassigned to a valid consumer, the tolerance in this case is:
+15min * number of consumer threads.
+
 ### Fallback
 
 After applying the retry policy if the computation is still in error, the computation uses the fallback directive `continueOnFailure`.

--- a/src/nxdoc/nuxeo-server/events-and-messages/nuxeo-stream.md
+++ b/src/nxdoc/nuxeo-server/events-and-messages/nuxeo-stream.md
@@ -303,9 +303,9 @@ ERROR [ComputationRunner] Terminate computation: <SOME_COMPUTATION_NAME> due to 
 
 There is also a `streamStatus` Nuxeo probe activated by default on the `runningstatus` endpoint health check.
 
-It is important to understand that this probe will report immediately a computation failure with a message like:
+It is important to understand that this probe will immediately report a computation failure with a message like:
 ```
- 2 computations have been terminated after failure. First failure detected: 2019-10-30 14:57:22Z, probe failure delayed by PT36H. This Nuxeo instance must be restarted within the stream retention period.
+2 computations have been terminated after failure. First failure detected: 2019-10-30 14:57:22Z, probe failure delayed by PT36H. This Nuxeo instance must be restarted within the stream retention period.
 ```
 **but** the probe failure is delayed by 36 hours in order to have time to apply the recovery procedure.
 

--- a/src/nxdoc/nuxeo-server/events-and-messages/nuxeo-stream.md
+++ b/src/nxdoc/nuxeo-server/events-and-messages/nuxeo-stream.md
@@ -282,19 +282,30 @@ There are different possible causes:
 
 A critical Computation in failure requires human intervention, so it is important to be alerted.
 
-The following metric can be monitored on each Nuxeo node, any not 0 value can trigger an alert:
+The following metric needs to be monitored on each Nuxeo node, any value greater than 0 should trigger an alert:
 ```
 nuxeo.nuxeo.stream.failure.count
 ```
 
-There is also a `streamStatus` Nuxeo probe, using the new Management REST API:
-```bash
-curl -XPOST -u Administrator:Administrator http://localhost:8080/nuxeo/site/management/probes/streamStatus
+Another way to be alerted is by monitoring the `server.log` file looking for error pattern like:
+```
+ERROR [ComputationRunner] Terminate computation: <SOME_COMPUTATION_NAME> due to previous failure
 ```
 
-The probe can be activated to be part of the `runningstatus` Nuxeo health check using the `nuxeo.conf` option:
+There is also a `streamStatus` Nuxeo probe activated by default on the `runningstatus` endpoint health check.
+
+It is important to understand that this probe will report immediately a computation failure with a message like:
 ```
-nuxeo.stream.healthCheck.enabled=true
+ 2 computations have been terminated after failure. First failure detected: 2019-10-30 14:57:22Z, probe failure delayed by PT36H. This Nuxeo instance must be restarted within the stream retention period.
+```
+**but** the probe failure is delayed by 36 hours in order to have time to apply the recovery procedure.
+
+This delay is necessary because most of the time the Nuxeo health check is used by load balancer and we don't want to interrupt
+the service immediately while we have time to fix the problem during the retention duration without downtime or data loss.
+
+The probe delay is configurable using the `nuxeo.conf` option, keep it under the retention duration (7 days when using Kafka).
+```
+nuxeo.stream.health.check.delay=36h
 ```
 
 ### Monitoring


### PR DESCRIPTION
For now only for FT no backport needed.