### PR TITLE
NXDRIVE-1408: Improve GNU/Linux details

### DIFF
--- a/src/client-apps/nuxeo-drive.md
+++ b/src/client-apps/nuxeo-drive.md
@@ -625,9 +625,9 @@ Icon | Old Icon | Status
 
 When you install Nuxeo Drive on your computer, it creates a "Nuxeo Drive" folder on your computer, from where you will be able to access the synchronized documents. This Nuxeo Drive folder is located:
 
-- in `C:\Users\USER\Documents\` on Windows
-- in `/Users/USER/` on macOS
-- in `/home/USER/` on GNU/Linux
+- GNU/Linux: `/home/USER/`
+- macOS: `/Users/USER/`
+- Windows: `C:\Users\USER\Documents\`
 
 Quick access to this folder is possible at any time using the Nuxeo Drive icon:
 

--- a/src/client-apps/nuxeo-drive/nuxeo-drive-faq.md
+++ b/src/client-apps/nuxeo-drive/nuxeo-drive-faq.md
@@ -146,14 +146,14 @@ Nuxeo Drive is guaranteed to run on ([history changes](https://github.com/nuxeo/
 ### Supported GNU/Linux Distributions
 
 {{#> callout type='note' }}
-This list is non-exhaustive, Nuxeo Drive may work on older versions and on non-listed distributions. If you successfully ran Nuxeo Drive on such OS, we would be pleased to update this page (you can [open an issue](https://github.com/nuxeo/doc.nuxeo.com-content/issues) or drop a line in whatever format you are familiar with).
+This list is non-exhaustive, Nuxeo Drive may work on non-listed distributions. If you successfully ran Nuxeo Drive on such OS, we would be pleased to update this page (you can [open an issue](https://github.com/nuxeo/doc.nuxeo.com-content/issues) or drop a line in whatever format you are familiar with).
 {{/callout}}
 
 Minimum supported versions:
 
-| Nuxeo Drive | Debian | Ubuntu | Fedora | Manjaro
+| Nuxeo Drive | Debian | Fedora | Manjaro | Ubuntu
 |---|---|---|---|---
-| >= 4.2.0 | 10 | 16.04 | 29 | 18.1.0
+| >= 4.2.0 | 9.0.0 | 25 | 18.1.0 | 16.04.1
 
 ## What Actions Trigger a Synchronization?
 

--- a/src/client-apps/nuxeo-drive/nuxeo-drive-installation-configuration.md
+++ b/src/client-apps/nuxeo-drive/nuxeo-drive-installation-configuration.md
@@ -43,6 +43,15 @@ After Nuxeo Drive has been installed on the server, a Nuxeo Drive tab in the use
 
 If you try to synchronize a folder and you haven't installed the Nuxeo Drive client yet or haven't provided your credentials to the Nuxeo Drive client, you are automatically directed to the Nuxeo Drive home tab to install it.
 
+#### Installing Nuxeo Drive on GNU/Linux
+
+1. Download the binary (`.AppImage` file) from the **Nuxeo Drive** tab in the **User Settings** or from the [Nuxeo Drive update site](https://community.nuxeo.com/static/drive-updates/nuxeo-drive-x86_64.AppImage).
+2. [Make the file executable](https://discourse.appimage.org/t/how-to-run-an-appimage/80).
+3. You now need to start Nuxeo Drive by clicking on the file.
+    A Nuxeo Drive folder will be created by the system at the root of your local home folder (`/home/USER/`). This is the place where synchronized documents will be stored on your computer.
+
+If you encounter any error, please check those pages: [Manual Usage](https://github.com/nuxeo/nuxeo-drive/blob/master/docs/gnu_linux.md) and [Troubleshooting](https://github.com/nuxeo/nuxeo-drive/blob/master/docs/gnu_linux_qa.md).
+
 #### Installing Nuxeo Drive on macOS
 
 1. Download the installer (`.dmg` file) from the **Nuxeo Drive** tab in the **User Settings** or from the [Nuxeo Drive update site](https://community.nuxeo.com/static/drive-updates/nuxeo-drive.dmg).
@@ -64,15 +73,6 @@ If you try to synchronize a folder and you haven't installed the Nuxeo Drive cli
 
 3. You now need to [start Nuxeo Drive](#starting-nuxeo-drive) to use it.
     A new Nuxeo Drive folder will be created by the system in your local Documents folder (`C:\Users\USER\Documents\`). This is the place where synchronized documents will be stored on your computer.
-
-#### Installing Nuxeo Drive on GNU/Linux
-
-1. Download the binary (`.AppImage` file) from the **Nuxeo Drive** tab in the **User Settings** or from the [Nuxeo Drive update site](https://community.nuxeo.com/static/drive-updates/nuxeo-drive-x86_64.AppImage).
-2. [Make the file executable](https://discourse.appimage.org/t/how-to-run-an-appimage/80).
-3. You now need to start Nuxeo Drive by clicking on the file.
-    A Nuxeo Drive folder will be created by the system at the root of your local home folder (`/home/USER/`). This is the place where synchronized documents will be stored on your computer.
-
-If you encounter any error, please check those pages: [Manual Usage](https://github.com/nuxeo/nuxeo-drive/blob/master/docs/gnu_linux.md) and [Troubleshooting](https://github.com/nuxeo/nuxeo-drive/blob/master/docs/gnu_linux_qa.md).
 
 ### Starting Nuxeo Drive
 
@@ -109,15 +109,15 @@ When a new version of Nuxeo Drive is available, a message is displayed at the bo
 
 {{> anchor 'open-drive-settings'}} **Accessing the Settings Window**
 
-#### Windows
-
-1. Right-click on the the icon ![]({{file name='drive-icon-online.png' page='nuxeo-drive'}} ?w=20) (or ![]({{file name='drive-icon-online-old.png' page='nuxeo-drive'}} ?w=14) on old versions) in the systray.
-2. Click on the icon ![]({{file name='drive-icon-settings.png' page='nuxeo-drive'}} ?w=20) and on the **Settings** menu item.</br>
-    The Settings window is displayed.
-
 #### macOS
 
 1. Click on the the icon ![]({{file name='drive-icon-online.png' page='nuxeo-drive'}} ?w=20) (or ![]({{file name='drive-icon-online-old.png' page='nuxeo-drive'}} ?w=14) on old versions) in the systray.
+2. Click on the icon ![]({{file name='drive-icon-settings.png' page='nuxeo-drive'}} ?w=20) and on the **Settings** menu item.</br>
+    The Settings window is displayed.
+
+#### Windows
+
+1. Right-click on the the icon ![]({{file name='drive-icon-online.png' page='nuxeo-drive'}} ?w=20) (or ![]({{file name='drive-icon-online-old.png' page='nuxeo-drive'}} ?w=14) on old versions) in the systray.
 2. Click on the icon ![]({{file name='drive-icon-settings.png' page='nuxeo-drive'}} ?w=20) and on the **Settings** menu item.</br>
     The Settings window is displayed.
 


### PR DESCRIPTION
- The minimum version supported on Debian is 9.0.0.
- The minimum version supported on Fedora is 25.
- The minimum version supported on Ubuntu is 16.04.1.
- I sorted paragraphs to be consistent though the whole documentation and Nuxeo Drive repository: GNU/Linux, then macOS and finally Windows.