### PR TITLE
Remove delivery notion (misleading)

### DIFF
--- a/src/nxdoc/nuxeo-add-ons/digital-asset-management-dam/supported-file-formats.md
+++ b/src/nxdoc/nuxeo-add-ons/digital-asset-management-dam/supported-file-formats.md
@@ -160,7 +160,7 @@ Metadata Extraction
 
 </th><th colspan="1">
 
-Transcode, delivery, watermarking
+Transcode, watermarking
 
 </th></tr><tr><th colspan="1">
 


### PR DESCRIPTION
Remove the delivery notion from the table header. It is misleading, will update the whole doc later with a larger approach.