### PR TITLE
Wide configuration table converted to headings

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
@@ -72,11 +72,7 @@ Administrators can also change the `nuxeo.conf` configuration parameters from th
 4.  If indicated as needed on top of the page, restart the server.
 
 {{#> callout type='tip' }}
-
-You can also take a look at the following pages for recommendations and examples:
-
-- [Setup Best Practices]({{page page='setup-best-practices'}})
-
+You can also take a look at the [following page]({{page page='setup-best-practices'}}) for recommendations and examples.
 {{/callout}}
 
 ## Configuration Parameters Index
@@ -87,8 +83,13 @@ The properties that can be set in nuxeo.conf are below. Properties that can be c
 
 Path to Java home directory.
 
-_Default value:_ None.<br/>
-If undefined nuxeoctl script will try to discover it.
+**Default Value**
+
+None.<br/>
+
+If undefined `nuxeoctl` script will try to discover it.
+
+* * *
 
 #### `JAVA_OPTS`
 
@@ -96,57 +97,89 @@ Optional values passed to the JVM.<br/>
 Nuxeo requires at least 1024 Mo in JVM heap size and 256Mo as maximum permanent size (512 recommended).<br/>
 Decreasing garbage collector frequency avoid having too much CPU usage (Sun Java specific options, recommended by JBoss).
 
-_Default value:_
-`-Xms512m -Xmx1024m -XX:MaxPermSize=512m`
-`-Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000`
+**Default Value**
+
+`-Xms512m -Xmx1024m -XX:MaxPermSize=512m`</br>
+`-Dsun.rmi.dgc.client.gcInterval=3600000`</br>
+`-Dsun.rmi.dgc.server.gcInterval=3600000`</br>
 `-Dfile.encoding=UTF-8`
+
+* * *
 
 #### `launcher.start.max.wait`
 
 In seconds. Maximum time to wait for effective Nuxeo server start before giving up (applies on commands "start" and "restart").
 
-_Default value:_ 300
+**Default Value**
+
+`300`
+
+* * *
 
 #### `launcher.stop.max.wait`
 
 In seconds. Maximum time to wait for effective Nuxeo server stop cleanly before using forced stop.
 
-_Default value:_ 60
+**Default Value**
+
+`60`
+
+* * *
 
 #### `launcher.override.java.tmpdir`
 
 Possible values: `true` or `false` .<br/>
 If true, will set `java.io.tmpdir = ${nuxeo.tmp.dir}`.
 
-_Default value:_ true
+**Default Value**
+
+`true`
+
+* * *
 
 #### `nuxeo.log.dir`
 
 Log directory (absolute or relative to `NUXEO_HOME`).<br/>
 Linux recommended path: `/var/log/nuxeo/...`
 
-_Default value:_ log
+**Default Value**
+
+`log`
+
+* * *
 
 #### `nuxeo.pid.dir`
 
 Directory where to store Nuxeo PID file.
 
-_Default value:_ bin
+**Default Value**
+
+`bin`
+
+* * *
 
 #### `nuxeo.data.dir`
 
 Data directory (absolute or relative to NUXEO_HOME). It involves all data not being stored in database.<br/>
 Linux recommended path: `/var/lib/nuxeo/...`
 
-_Default value:_ data
+**Default Value**
+
+`data`
+
+* * *
 
 #### `nuxeo.tmp.dir`
 
 Location of the temporary files.
 
-_Default value:_ `server/default/tmp` (JBoss)<br/>
+**Default Value**
+
+`server/default/tmp` (JBoss)<br/>
 `tmp` (Tomcat)<br/>
 `tmp` (Jetty)
+
+* * *
 
 #### `nuxeo.mp.dir`
 
@@ -154,7 +187,11 @@ _Default value:_ `server/default/tmp` (JBoss)<br/>
 
 Since Nuxeo 5.9.4\. Nuxeo Packages directory.
 
-_Default value:_ `packages`
+**Default Value**
+
+`packages`
+
+* * *
 
 #### `nuxeo.force.generation`
 
@@ -162,7 +199,11 @@ If "`true`", will force generation of configuration files; otherwise they are on
 If "`once`", will force one time and switch to false after successful generation.<br/>
 If "`false`", configuration changes are ignored.
 
-_Default value:_ `true` | `once`
+**Default Value**
+
+`true` | `once`
+
+* * *
 
 #### `nuxeo.templates`
 
@@ -170,20 +211,32 @@ Comma separated list of templates to include.<br/>
 Templates paths are absolute or relative to `$NUXEO_HOME/templates/`.<br/>
 Available templates: postgresql, mysql, mssql, oracle, custom, ...
 
-_Default value:_ default
+**Default Value**
+
+`default`
+
+* * *
 
 #### `nuxeo.bind.address`
 
 Server binding address. "0.0.0.0" means "all available network interfaces".<br/>
 WARNING: When changing `nuxeo.bind.address`, you must accordingly change `nuxeo.loopback.url`.
 
-_Default value:_ 0.0.0.0
+**Default Value**
+
+`0.0.0.0`
+
+* * *
 
 #### `nuxeo.server.http.port`
 
 Server HTTP listen port.
 
-_Default value:_ 8080
+**Default Value**
+
+`8080`
+
+* * *
 
 #### `nuxeo.server.http.connectionUploadTimeout`
 
@@ -191,20 +244,32 @@ _Default value:_ 8080
 
 Since 10.3. Configure the Tomcat `connectionUploadTimeout` to specify the timeout, in milliseconds, to use while a data upload is in progress.
 
-_Default value:_ 60000
+**Default Value**
+
+`60000`
+
+* * *
 
 #### `nuxeo.server.ajp.port`
 
 Server AJP listen port.<br/>
 This is not available on Jetty.
 
-_Default value:_ 8009
+**Default Value**
+
+`8009`
+
+* * *
 
 #### `nuxeo.server.jvmRoute`
 
 Server AJP route for load-balancing
 
-_Default value:_ nuxeo
+**Default Value**
+
+`nuxeo`
+
+* * *
 
 #### `nuxeo.server.tomcat_admin.host`
 
@@ -213,7 +278,11 @@ _Default value:_ nuxeo
 Since Nuxeo 7.3\. Tomcat server's "admin" host.<br/>
 This is the address on which the server waits for a shutdown command.
 
-_Default value:_ localhost
+**Default Value**
+
+`localhost`
+
+* * *
 
 #### `nuxeo.server.tomcat-admin.port`
 
@@ -222,7 +291,11 @@ _Default value:_ localhost
 Deprecated since Nuxeo 5.6 and replaced by `nuxeo.server.tomcat_admin.port`. Tomcat server's "admin" port.<br/>
 This is only useful if you have another Tomcat server running and want to avoid port conflicts.
 
-_Default value:_ 8005
+**Default Value**
+
+`8005`
+
+* * *
 
 #### `nuxeo.server.tomcat_admin.port`
 
@@ -231,7 +304,11 @@ _Default value:_ 8005
 Since Nuxeo 5.6\. Tomcat server's "admin" port.<br/>
 Replaces `nuxeo.server.tomcat-admin.port`. This is only useful if you have another Tomcat server running and want to avoid port conflicts.
 
-_Default value:_ 8005
+**Default Value**
+
+`8005`
+
+* * *
 
 #### `nuxeo.server.tomcat_error.show_report`
 
@@ -239,7 +316,11 @@ _Default value:_ 8005
 
 Tomcat report displayed or not on Tomcat error page.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.server.tomcat_error.show_server_info`
 
@@ -247,14 +328,22 @@ _Default value:_ false
 
 Tomcat version info (as Tomcat server version) displayed or not on Tomcat error page.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.server.https.port`
 
 Server HTTPS listen port.<br/>
 This is only useful if you have modified the application server to use HTTPS.
 
-_Default value:_ 8443
+**Default Value**
+
+`8443`
+
+* * *
 
 #### `nuxeo.server.emptySessionPath`
 
@@ -264,37 +353,61 @@ _Default value:_ 8443
 May be useful to enable authentication on proxyfied WebEngine applications (see [HTTP and HTTPS Reverse-Proxy Configuration]({{page page='http-and-https-reverse-proxy-configuration'}})).<br/>
 Removed since Nuxeo 5.7.2 (see [http://tomcat.apache.org/migration-7.html#Session_cookie_configuration](http://tomcat.apache.org/migration-7.html#Session_cookie_configuration)).
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.server.signature`
 
 (Tomcat only) Since Nuxeo 6.0\. If set, this will replace the default value of the "Server:" HTTP response header.
 
-_Default value:_ None
+**Default Value**
+
+None.
+
+* * *
 
 #### `org.nuxeo.ecm.instance.name`
 
 Server name.
 
-_Default value:_ Nuxeo 5.9.3-SNAPSHOT
+**Default Value**
+
+`Nuxeo 5.9.3-SNAPSHOT`
+
+* * *
 
 #### `org.nuxeo.ecm.instance.description`
 
 Server description.
 
-_Default value:_ Nuxeo
+**Default Value**
+
+`Nuxeo`
+
+* * *
 
 #### `org.nuxeo.ecm.product.name`
 
 Product name, displayed in the page title on your browser.
 
-_Default value:_ Nuxeo Platform
+**Default Value**
+
+`Nuxeo Platform`
+
+* * *
 
 #### `org.nuxeo.ecm.product.version`
 
-_Default value:_ 5.9.3-SNAPSHOT
+**Default Value**
 
-### {{> anchor 'orgnuxeodev'}} `org.nuxeo.dev`
+`5.9.3-SNAPSHOT`
+
+* * *
+
+#### {{> anchor 'orgnuxeodev'}} `org.nuxeo.dev`
 
 **Since Nuxeo 5.6**
 
@@ -302,7 +415,11 @@ Since Nuxeo 5.6, this property uses the "dev" mode when running the Nuxeo applic
 
 Before 5.6, setting this property to true stopped the runtime when an error occured at deployment. This behaviour has been removed from the dev mode and is now controlled by the property `org.nuxeo.runtime.strict`.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `org.nuxeo.prod`
 
@@ -310,9 +427,13 @@ _Default value:_ false
 
 Since Nuxeo 5.8, setting this property to "true" will display a quite visible warning message in the Admin tab, stating that this is a production instance. This is useful for administrators who are sometimes confusing their Nuxeo production server with their test server (not to rat anyone out).
 
-_Default value:_ false
+**Default Value**
 
-### {{! multiexcerpt name='org.nuxeo.rest.stack.enable'}}`org.nuxeo.rest.stack.enable`
+`false`
+
+* * *
+
+#### {{! multiexcerpt name='org.nuxeo.rest.stack.enable'}}`org.nuxeo.rest.stack.enable`
 
 {{! /multiexcerpt}}
 
@@ -324,32 +445,34 @@ Since Nuxeo 6.0, you can enable this mode if you'd like to display exception sta
 See [Web Exceptions documentation]({{page page='error-handling'}}) to get modes description and examples.
 {{! /multiexcerpt}}
 
-_Default value:_ {{! multiexcerpt name='org.nuxeo.rest.stack.enable-default'}}
-false
+**Default Value**
+
+{{! multiexcerpt name='org.nuxeo.rest.stack.enable-default'}}
+`false`
 {{! /multiexcerpt}}
 
-### {{! multiexcerpt name='org.nuxeo.automation.trace'}}
+* * *
 
-`org.nuxeo.automation.trace`
+#### {{! multiexcerpt name='org.nuxeo.automation.trace'}}`org.nuxeo.automation.trace`
 {{! /multiexcerpt}}
 
 Enable this mode if you'd like to display automation traces during runtime:<br/>
 
 {{! multiexcerpt name='org.nuxeo.automation.trace-description'}}
-
 - You'll benefit from exhaustive logs to debug all automation chain and/or operation execution.<br/>
 - The automation trace mode is disabled by default (not suitable for production).<br/>
 - It can be activated through JMX via `org.nuxeo:TracerFactory` MBean during runtime.
 
 {{! /multiexcerpt}}
+**Default Value**
 
-_Default value:_ {{! multiexcerpt name='org.nuxeo.automation.trace-default'}}
-false
+{{! multiexcerpt name='org.nuxeo.automation.trace-default'}}
+`false`
 {{! /multiexcerpt}}
 
-### {{! multiexcerpt name='org.nuxeo.automation.trace.printable'}}
+* * *
 
-`org.nuxeo.automation.trace.printable`
+#### {{! multiexcerpt name='org.nuxeo.automation.trace.printable'}}`org.nuxeo.automation.trace.printable`
 {{! /multiexcerpt}}
 
 {{! multiexcerpt name='org.nuxeo.automation.trace.printable-description'}}
@@ -357,29 +480,45 @@ By default, all automation executions are 'printable' (appear in logs) when auto
 
 - You can filter chain and/or operation execution trace printing by setting this property to chain name and/or operation separated by comma.<br/>
 - Comment this property to get all automation chains/operations back in printing (by default set to \* (star))
-
 {{! /multiexcerpt}}
 
-_Default value:_ {{! multiexcerpt name='org.nuxeo.automation.trace.printable-default'}} \*
+**Default Value**
+
+{{! multiexcerpt name='org.nuxeo.automation.trace.printable-default'}}
+`*`
 {{! /multiexcerpt}}
+
+* * *
 
 #### `templateName.target`
 
 Directory where _templateName_ files will be deployed.
 
-_Default value:_ `server/default/deploy/nuxeo.ear`
+**Default Value**
+
+`server/default/deploy/nuxeo.ear`
+
+* * *
 
 #### `mailservice.user`
 
 (JBoss only) User for e-mail authentication.
 
-_Default value:_ nobody
+**Default Value**
+
+nobody
+
+* * *
 
 #### `mailservice.password`
 
 (JBoss only) Password for e-mail authentication.
 
-_Default value:_ password
+**Default Value**
+
+password
+
+* * *
 
 #### `mail.store.protocol`<br/>
 
@@ -387,141 +526,235 @@ _Default value:_ password
 
 Server protocol parameters for e-mailing.
 
-_Default value:_ pop3<br/>
-smtp
+**Default Value**
+
+`pop3`<br/>
+`smtp`
+
+* * *
 
 #### `mail.user`
 
 User who will receive e-mail (unused in Nuxeo).
 
-_Default value:_ nobody
+**Default Value**
+
+nobody
+
+* * *
 
 #### `mail.store.host`
 
 e-Mail server.
 
-_Default value:_ localhost
+**Default Value**
+
+localhost
+
+* * *
 
 #### `mail.store.user`
 
-_Default value:_ anonymous
+**Default Value**
+
+anonymous
+
+* * *
 
 #### `mail.store.password`
 
-_Default value:_ password
+**Default Value**
+
+password
+
+* * *
 
 #### `mail.debug`
 
 Enable debugging output from the JavaMail classes.
 
-_Default value:_ false
+**Default Value**
+
+false
+
+* * *
 
 #### `nuxeo.notification.eMailSubjectPrefix`
 
 Subject prefix in Nuxeo notification e-mails.
 
-_Default value:_ [Nuxeo]
+**Default Value**
+
+[Nuxeo]
+
+* * *
 
 #### `nuxeo.notification.eMailSigner`
 
 Signer of the sent e-mail.
 
-_Default value:_ The Nuxeo team
+**Default Value**
+
+The Nuxeo team
+
+* * *
 
 #### `mail.transport.host`
 
 SMTP gateway server.
 
-_Default value:_ localhost
+**Default Value**
+
+localhost
+
+* * *
 
 #### `mail.transport.port`
 
 e-Mail server port.
 
-_Default value:_ 25 (without authentication)<br/>
-587 (with authentication)<br/>
-465 (SSL)
+**Default Value**
+
+`25` (without authentication)<br/>
+`587` (with authentication)<br/>
+`465` (SSL)
+
+* * *
 
 #### `mail.transport.usetls`
 
 Use TLS for the SMTP connection.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `mail.transport.auth`
 
-_Default value:_ true
+**Default Value**
+
+`true`
+
+* * *
 
 #### `mail.transport.user`
 
-_Default value:_ anonymous
+**Default Value**
+
+anonymous
+
+* * *
 
 #### `mail.transport.password`
 
-_Default value:_ password
+**Default Value**
+
+password
+
+* * *
 
 #### `mail.from`
 
 The e-mail address will be sent from.
 
-_Default value:_ noreply@nuxeo.com
+**Default Value**
+
+`noreply@nuxeo.com`
+
+* * *
 
 #### `nuxeo.db.name`
 
 Database name.
 
-_Default value:_ nuxeo | NUXEO
+**Default Value**
+
+`nuxeo` | `NUXEO`
+
+* * *
 
 #### `nuxeo.db.user`
 
 Database username.
 
-_Default value:_ sa | nuxeo
+**Default Value**
+
+`sa` | `nuxeo`
+
+* * *
 
 #### `nuxeo.db.password`
 
 Database password.
 
-_Default value:_ (empty value) | password
+**Default Value**
+
+(empty value) | `password`
+
+* * *
 
 #### `nuxeo.db.host`
 
 Database host URL.
 
-_Default value:_ localhost
+**Default Value**
+
+`localhost`
+
+* * *
 
 #### `nuxeo.db.port`
 
 Database host port.
 
-_Default value:_ 3700 (DB2)<br/>
-5432 (PostgreSQL)<br/>
-3306 (MySQL)<br/>
-1521 (Oracle)<br/>
-1433 (MSSQL)
+**Default Value**
+
+`3700` (DB2)<br/>
+`5432` (PostgreSQL)<br/>
+`3306` (MySQL)<br/>
+`1521` (Oracle)<br/>
+`1433` (MSSQL)
+
+* * *
 
 #### `nuxeo.db.jdbc.url`
 
 Database JDBC connection URL for Nuxeo datasources, for instance `jdbc:postgresql://${nuxeo.db.host}:${nuxeo.db.port}/${nuxeo.db.name`}.
 
-_Default value:_ (database-dependent)
+**Default Value**
+
+(database-dependent)
+
+* * *
 
 #### `nuxeo.db.validationQuery`
 
 Database validation query, a `SELECT` statement used to check connections before using them, usually `SELECT 1`. Using this has a noticeable speed impact but makes connections resilient to network or sever problems.
 
+* * *
+
 #### `nuxeo.db.min-pool-size`
 
 Database minimum pool size for Nuxeo datasources.
 
-_Default value:_ 5
+**Default Value**
+
+`5`
+
+* * *
 
 #### `nuxeo.db.max-pool-size`
 
 Database maximum pool size for Nuxeo datasources.
 
-_Default value:_ 20 (JBoss)<br/>
-100 (Tomcat)
+**Default Value**
+
+`20` (JBoss)<br/>
+`100` (Tomcat)
+
+* * *
 
 #### `nuxeo.db.idle-timeout-minutes`
 
@@ -529,25 +762,41 @@ _Default value:_ 20 (JBoss)<br/>
 
 Since Nuxeo 6.0\. Database timeout after which connections not in use are removed from the pool.
 
-_Default value:_ 5
+**Default Value**
+
+`5`
+
+* * *
 
 #### `nuxeo.db.xaMode`
 
 Enable XA mode (required if multiple datasources configured)
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.vcs.min-pool-size`
 
 Database minimum pool size for Nuxeo repository (VCS).
 
-_Default value:_ 0
+**Default Value**
+
+`0`
+
+* * *
 
 #### `nuxeo.vcs.max-pool-size`
 
 Database maximum pool size for Nuxeo repository (VCS).
 
-_Default value:_ 20
+**Default Value**
+
+`20`
+
+* * *
 
 #### `nuxeo.vcs.blocking-timeout-millis`
 
@@ -555,7 +804,11 @@ _Default value:_ 20
 
 Since Nuxeo 5.8\. Database maximum wait time to get a connection from the pool when all connections are in use, for Nuxeo repository (VCS).
 
-_Default value:_ 100
+**Default Value**
+
+`100`
+
+* * *
 
 #### `nuxeo.vcs.idle-timeout-minutes`
 
@@ -563,7 +816,11 @@ _Default value:_ 100
 
 Since Nuxeo 5.8\. Database timeout after which connections not in use are removed from the pool, for Nuxeo repository (VCS).
 
-_Default value:_ 10
+**Default Value**
+
+`10`
+
+* * *
 
 #### `nuxeo.vcs.fulltext.disabled`
 
@@ -571,7 +828,11 @@ _Default value:_ 10
 
 Since Nuxeo 5.8\. Whether full text indexing and querying should be completely disabled in the repository. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.vcs.fulltext.search.disabled`
 
@@ -579,7 +840,11 @@ _Default value:_ false
 
 Since Nuxeo 6.0\. Full text querying from VCS (database backend) is disabled, full text extraction is done. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.vcs.fulltext.analyzer.language`
 
@@ -587,7 +852,11 @@ _Default value:_ false
 
 Since Nuxeo 7.3\. Full text analyzer language. Only applies to&nbsp;`postgresql` and `mssql` database types.
 
-_Default value:_ english
+**Default Value**
+
+`english`
+
+* * *
 
 #### `nuxeo.vcs.noddl`
 
@@ -595,7 +864,11 @@ _Default value:_ english
 
 Since Nuxeo 5.8\. Where DDL generation should be disabled in the repository. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.vcs.ddlmode`
 
@@ -603,7 +876,11 @@ _Default value:_ false
 
 Since Nuxeo 7.10-HF01 and Nuxeo 8.1\. What kind of DDL generation is done. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
 
-_Default value:_ execute
+**Default Value**
+
+`execute`
+
+* * *
 
 #### `nuxeo.vcs.idtype`
 
@@ -611,7 +888,11 @@ _Default value:_ execute
 
 Since Nuxeo 5.8\. The type of `id` column. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
 
-_Default value:_ varchar
+**Default Value**
+
+`varchar`
+
+* * *
 
 #### `nuxeo.vcs.copy.findFreeName.disabled`
 
@@ -619,58 +900,94 @@ _Default value:_ varchar
 
 Since Nuxeo 7.3\. Set to true to disable free-name detection and let the database raise a constraint error in case of collisions **if the constraints have been added by hand**.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.url`
 
 Application URL (without final slash), should be the public URL of your server (i.e.: [http://www.yourdomain.com/](http://www.yourdomain.com/)....)<br />
 It is also used for emails sent out and to detect images in HTML documents when converting to PDF.
 
-_Default value:_ http://localhost:8080/nuxeo
+**Default Value**
+
+`http://localhost:8080/nuxeo`
+
+* * *
 
 #### `nuxeo.loopback.url`
 
 Nuxeo URL, for connections from Nuxeo to itself (theme banks default). The port should be the same as `nuxeo.server.http.port.`<br/>
 If not explicitly configured, the loop back URL is generated from `nuxeo.bind.address`, `nuxeo.server.http.port` and `org.nuxeo.ecm.contextPath` values.
 
-_Default value:_ http://localhost:8080/nuxeo
+**Default Value**
+
+`http://localhost:8080/nuxeo`
+
+* * *
 
 #### `org.nuxeo.ecm.contextPath`
 
 Application context path.<br/>
 Note: Changing this parameter is not enough. See [HOWTO: Change Context Path]({{page page='setup-best-practices'}})
 
-_Default value:_ /nuxeo
+**Default Value**
+
+`/nuxeo`
+
+* * *
 
 #### `org.nuxeo.ecm.platform.transform.ooo.host.name`
 
 DEPRECATED.
 
-_Default value:_ 127.0.0.1
+**Default Value**
+
+`127.0.0.1`
+
+* * *
 
 #### `org.nuxeo.ecm.platform.transform.ooo.host.port`
 
 DEPRECATED.
 
-_Default value:_ 8100
+**Default Value**
+
+`8100`
+
+* * *
 
 #### `org.nuxeo.ecm.platform.transform.ooo.version`
 
 DEPRECATED.
 
-_Default value:_ 2.2.1
+**Default Value**
+
+`2.2.1`
+
+* * *
 
 #### `org.nuxeo.ecm.platform.transform.ooo.enableDaemon`
 
 DEPRECATED.
 
-_Default value:_ true
+**Default Value**
+
+`true`
+
+* * *
 
 #### `repository.clustering.enabled`
 
 Activate clustering mode.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `repository.clustering.id`
 
@@ -678,25 +995,39 @@ _Default value:_ false
 
 Since Nuxeo 7.3\. The cluster node id for this Nuxeo instance. The id must be an integer for all databases, unless you are using Oracle which accepts a string (See [NXP-17180](https://jira.nuxeo.com/browse/NXP-17180)).
 
+* * *
+
 #### `repository.clustering.delay`
 
 When clustering is activated, defines the delay during which invalidations don't need to be processed (expressed in milliseconds).
 
-_Default value:_ 1000
+**Default Value**
+
+`1000`
+
+* * *
 
 #### `repository.clustering.invalidation`
 
 Allows the configuration of VCS cluster invalidations. The value `default` uses VCS. Since Nuxeo 8.1 you can use `redis` to specify Redis-based invalidations.
 
-_Default value:_ default
+**Default Value**
+
+`default`
+
+* * *
 
 #### `repository.binary.store`
 
 Defines the folder where binaries are stored. Useful when using clustering or to change the location of binaries to another location.
 
+* * *
+
 #### `nuxeo.core.binarymanager`
 
 Custom class for the Binary Manager, to replace the default file-base storage.
+
+* * *
 
 #### `nuxeo.core.binarymanager_key`
 
@@ -704,13 +1035,19 @@ Custom class for the Binary Manager, to replace the default file-base storage.
 
 Since Nuxeo 6.0\. Key configuration for the binary manager, if applicable.
 
+* * *
+
 #### `nuxeo.templates.parsing.extensions`
 
 **Deprecated since Nuxeo 5.6**
 
 Deprecated since Nuxeo 5.6\. Files extensions being parsed for parameters replacement when copying templates.
 
-_Default value:_ xml,properties
+**Default Value**
+
+`xml,properties`
+
+* * *
 
 #### `nuxeo.plaintext_parsing_extensions`
 
@@ -718,14 +1055,22 @@ _Default value:_ xml,properties
 
 Since Nuxeo 5.6\. Files extensions being parsed for parameters replacement when copying templates.
 
-_Default value:_ xml,properties
+**Default Value**
+
+`xml,properties`
+
+* * *
 
 #### `org.nuxeo.ecm.jboss.configuration`
 
 JBoss configuration to use (`default`, `minimal`, `all`, ...)<br/>
 Pay attention to the fact that this won't apply to templates defining their own `_template_.target` value (for instance, "default" template sets `default.target=server/default/deploy` without being aware of `org.nuxeo.ecm.jboss.configuration` value).
 
-_Default value:_ default
+**Default Value**
+
+`default`
+
+* * *
 
 #### `zip.entry.encoding`
 
@@ -736,37 +1081,57 @@ Since Nuxeo 7.1, the ZIP entries names are encoded in UTF8 by default. If you wa
 
 #### `org.nuxeo.ecm.platform.liveedit.autoversioning`
 
-_Default value:_ none,minor,major
+**Default Value**
+
+`none`, `minor`, `major`
+
+* * *
 
 #### `nuxeo.wizard.done`
 
 If set to false, will start a setup wizard before starting Nuxeo.
 
-_Default value:_ true or false depending on the package
+**Default Value**
+
+`true`| `false` (depending on the package)
+
+* * *
 
 #### `nuxeo.http.proxy.host`
 
 HTTP proxy host.
 
+* * *
+
 #### `nuxeo.http.proxy.port`
 
 HTTP proxy port.
+
+* * *
 
 #### `nuxeo.http.proxy.login`
 
 HTTP proxy login.
 
+* * *
+
 #### `nuxeo.http.proxy.password`
 
 HTTP proxy password.
+
+* * *
 
 #### `nuxeo.http.proxy.ntlm.host`
 
 NT Lan Manager (NTLM) Proxy. Host name of the Windows machine running the Nuxeo server.
 
+* * *
+
 #### `nuxeo.http.proxy.ntlm.domain`
 
 NT Lan Manager (NTLM) Proxy. Domain name to authenticate against.
+
+* * *
 
 #### `nuxeo.http.proxy.pac.url`
 
@@ -774,30 +1139,46 @@ NT Lan Manager (NTLM) Proxy. Domain name to authenticate against.
 
 Since Nuxeo 5.9.3\. Proxy auto-config (PAC) file URL.
 
+* * *
+
 #### `facelets.REFRESH_PERIOD`
 
 Indicates to the compiler the number of seconds to wait between subsequent checks for changes in modified JSF facelets in a running application. Useful for facelet debugging.<br/>
 To disable this compiler check use a value of -1 which is a recommended value for production deployments as compiler checks have an impact on application performance.<br/>
 Since Nuxeo 5.6, the parameter [`undefined`](#orgnuxeodev) should be used instead as it forces this parameter to value "2".
 
-_Default value:_ -1
+**Default Value**
+
+`-1`
+
+* * *
 
 #### `nuxeo.db.transactiontimeout`
 
 Database transaction timeout in seconds (available for Tomcat server only)
 
-_Default value:_ 300
+**Default Value**
+
+`300`
+
+* * *
 
 #### `server.status.key`
 
 Secure key for connecting to server status monitoring servlet. It is randomly generated if not set.<br/>
 It is also used by default&nbsp;for sensitive configuration data encryption, see `server.crypt.secretkey`.
 
+* * *
+
 #### `session.timeout`
 
 Session timeout (see [web.xml session-timeout](http://www.google.com/search?q=web.xml+session-timeout)).
 
-_Default value:_ 60
+**Default Value**
+
+`60`
+
+* * *
 
 #### `session.config.tracking.mode.cookie`
 
@@ -807,19 +1188,31 @@ Session tracking mode.<br/>
 If `true`, prevents Tomcat from appending the `jsessionid` parameter to the URLs, for example a file download URL. Yet, cookies need to be enabled in the browser.<br/>
 Otherwise, the `jsessionid` parameter might be appended to some URLs, for instance when sharing a document permalink to an anonymous user or when clearing the browser's cookies. Yet, cookies don't need to be enabled in the browser.
 
-_Default value:_ `true`
+**Default Value**
+
+`true`
+
+* * *
 
 #### `nuxeo.updatecenter.disabled`
 
 Disables the Update Center feature.
 
-_Default value:_ false (unset)
+**Default Value**
+
+`false` (unset)
+
+* * *
 
 #### `org.nuxeo.big.file.size.limit`
 
 Redirects onto the big file download URL if size exceeds limit.
 
-_Default value:_ 5Mi (unset)
+**Default Value**
+
+`5Mi` (unset)
+
+* * *
 
 #### `org.nuxeo.ecm.platform.ui.web.auth`<br/>
 
@@ -827,17 +1220,27 @@ _Default value:_ 5Mi (unset)
 
 Disables login synchronization.
 
-_Default value:_ false (unset)
+**Default Value**
+
+`false` (unset)
+
+* * *
 
 #### `nuxeo.wizard.packages.url`
 
 Defines the base URL used by the Setup Wizard to get the packages.xml file describing the available software packages options.
 
+* * *
+
 #### `nuxeo.wizard.skippedpages`
 
 Comma separated list of pages that should be skipped inside the wizard.
 
-_Default value:_ null
+**Default Value**
+
+`null`
+
+* * *
 
 #### `nuxeo.jsf. numberOfConversationsInSession`
 
@@ -845,7 +1248,11 @@ _Default value:_ null
 
 Since Nuxeo 5.7.2, Parameter to control the number of conversation states that are saved in session. Each conversation holds a number of view states that is defined by `nuxeo.jsf.numberOfViewsInSession`
 
-_Default value:_ 4
+**Default Value**
+
+`4`
+
+* * *
 
 #### `nuxeo.jsf.numberOfViewsInSession`
 
@@ -853,7 +1260,11 @@ _Default value:_ 4
 
 Since Nuxeo 5.7.2 (5.6-HF20) Parameter to control the JSF init parameter `com.sun.faces.numberOfViewsInSession`
 
-_Default value:_ 4
+**Default Value**
+
+`4`
+
+* * *
 
 #### `nuxeo.jsf.numberOfLogicalViews`
 
@@ -861,7 +1272,11 @@ _Default value:_ 4
 
 Since Nuxeo 5.7.2 (5.6-HF20) Parameter to control the JSF init parameter `com.sun.faces.numberOfLogicalViews`
 
-_Default value:_ 4
+**Default Value**
+
+`4`
+
+* * *
 
 #### `nuxeo.jsf.tmp.dir`
 
@@ -869,7 +1284,11 @@ _Default value:_ 4
 
 Since Nuxeo 6.0\. Faces Servlet multi-part config: an absolute path to a directory on the file system. The location attribute does **not** support a path relative to the application context. This location is used to store files temporarily while the parts are processed or when the size of the file exceeds the specified `fileSizeThreshold` setting. The default location is "".
 
-_Default value:_ `nuxeo.tmp.dir` (unset)</span>
+**Default Value**
+
+`nuxeo.tmp.dir` (unset)</span>
+
+* * *
 
 #### `nuxeo.jsf.maxFileSize`
 
@@ -877,7 +1296,11 @@ _Default value:_ `nuxeo.tmp.dir` (unset)</span>
 
 Since Nuxeo 6.0\. Faces Servlet multi-part config: the maximum size allowed for uploaded files, in bytes. The default size is unlimited.
 
-_Default value:_ -1 (unlimited) (unset)
+**Default Value**
+
+`-1` (unlimited) (unset)
+
+* * *
 
 #### `nuxeo.jsf.maxRequestSize`
 
@@ -885,7 +1308,11 @@ _Default value:_ -1 (unlimited) (unset)
 
 Since Nuxeo 6.0\. Faces Servlet multi-part config: the maximum size allowed for a `multipart/form-data` request, in bytes. The default size is unlimited.
 
-_Default value:_ -1 (unlimited) (unset)
+**Default Value**
+
+`-1` (unlimited) (unset)
+
+* * *
 
 #### `nuxeo.jsf.fileSizeThreshold`
 
@@ -893,7 +1320,11 @@ _Default value:_ -1 (unlimited) (unset)
 
 Since Nuxeo 6.0\. Faces Servlet multi-part config: The file size in bytes after which the file will be temporarily stored on disk. The default size is 0 bytes.
 
-_Default value:_ 0 (unset)
+**Default Value**
+
+`0` (unset)
+
+* * *
 
 #### `nuxeo.vcs.use-nulls-last-on-desc`
 
@@ -902,7 +1333,11 @@ _Default value:_ 0 (unset)
 Since Nuxeo 5.8\. Ask the database to use "NULLS LAST" when sorting DESC. True by default to get the same result order between different databases.<br/>
 Also turning this option to false enable PostgreSQL and Oracle to use an index on the sorted column which can be huge performance improvement.
 
-_Default value:_ true (unset)
+**Default Value**
+
+`true` (unset)
+
+* * *
 
 #### `org.nuxeo.connect.connector.cache.duration`
 
@@ -910,7 +1345,11 @@ _Default value:_ true (unset)
 
 Since Nuxeo 5.6\. Nuxeo Packages list cache (in minutes).
 
-_Default value:_ 60min (5min for Studio packages)
+**Default Value**
+
+`60min` (5min for Studio packages)
+
+* * *
 
 #### `org.nuxeo.connect.server.reachable`
 
@@ -918,19 +1357,31 @@ _Default value:_ 60min (5min for Studio packages)
 
 Since Nuxeo 5.7\. Launcher online/offline mode for connections to Nuxeo Connect.
 
-_Default value:_ true
+**Default Value**
+
+`true`
+
+* * *
 
 #### `org.nuxeo.connect.url`
 
 Nuxeo Connect URL.
 
-_Default value:_ [https://connect.nuxeo.com/nuxeo/site/](https://connect.nuxeo.com/nuxeo/site/)
+**Default Value**
+
+`https://connect.nuxeo.com/nuxeo/site/`
+
+* * *
 
 #### `nuxeo.automation.properties.multiline.escape`
 
 Enable/Disable multi-line strings escaped with a trailing \ when using `Document.Update` or `Workflow.SetWorkflowVariables` Automation operations.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `org.nuxeo.cmis.joins`
 
@@ -938,7 +1389,11 @@ _Default value:_ false
 
 Since Nuxeo 6.0\. When true, CMISQL JOINs are allowed if VCS is used.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `org.nuxeo.cmis.proxies`
 
@@ -946,7 +1401,11 @@ _Default value:_ false
 
 If false, proxies are not visible through CMIS. Cannot be `true` if `org.nuxeo.cmis.joins` is `true`.
 
-_Default value:_ true
+**Default Value**
+
+`true`
+
+* * *
 
 #### `org.nuxeo.cmis.enableComplexProperties`
 
@@ -954,7 +1413,11 @@ _Default value:_ true
 
 Since Nuxeo 7.1\. When true, complex properties are exposed as JSON-encoded strings.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.security.allowNegativeACL`
 
@@ -962,7 +1425,11 @@ _Default value:_ false
 
 Since Nuxeo 6.0\. When true, enables adding negative ACL (deny permissions) in the UI, otherwise only grant permissions are available.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `audit.elasticsearch.enabled`
 
@@ -971,7 +1438,11 @@ _Default value:_ false
 Since Nuxeo 7.3\. See [Disabling Elasticsearch for Audit Logs]({{page version='' space='nxdoc' page='elasticsearch-setup'}}#disabling-elasticsearch-for-audit-logs).<br/>
 Defaults to false on server upgrade, true on new install.
 
-_Default value:_ false | true
+**Default Value**
+
+`false` | `true`
+
+* * *
 
 #### `audit.elasticsearch.indexName`
 
@@ -979,7 +1450,11 @@ _Default value:_ false | true
 
 Name of the Elasticsearch index for audit logs.
 
-_Default value:_ `${elasticsearch.indexName}`-audit
+**Default Value**
+
+`${elasticsearch.indexName}`-audit
+
+* * *
 
 #### `seqgen.elasticsearch.indexName`
 
@@ -987,7 +1462,11 @@ _Default value:_ `${elasticsearch.indexName}`-audit
 
 Name of the Elasticsearch index for the uid sequencer.
 
-_Default value:_ `${elasticsearch.indexName}`-uidgen
+**Default Value**
+
+`${elasticsearch.indexName}`-uidgen
+
+* * *
 
 #### `audit.elasticsearch.migration`
 
@@ -995,7 +1474,11 @@ _Default value:_ `${elasticsearch.indexName}`-uidgen
 
 Since Nuxeo 7.3\. See [Triggering SQL to Elasticsearch Audit Logs Migration]({{page version='710' space='admindoc' page='elasticsearch-setup'}}#triggering-sql-to-elasticsearch-audit-logs-migration)
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `audit.elasticsearch.migration.batchSize`
 
@@ -1003,7 +1486,11 @@ _Default value:_ false
 
 Since Nuxeo 7.3\. See [Triggering SQL to Elasticsearch Audit Logs Migration]({{page version='710' space='admindoc' page='elasticsearch-setup'}}#triggering-sql-to-elasticsearch-audit-logs-migration)
 
-_Default value:_ 1000
+**Default Value**
+
+`1000`
+
+* * *
 
 #### `elasticsearch.httpReadOnly.baseUrl`
 
@@ -1011,7 +1498,11 @@ _Default value:_ 1000
 
 Required when using a standalone Elasticsearch instance. See [Elasticsearch Passthrough]({{page version='' space='nxdoc' page='elasticsearch-passthrough'}}#requirement)
 
-_Default value:_ http://localhost:9200/
+**Default Value**
+
+`http://localhost:9200/`
+
+* * *
 
 #### `org.nuxeo.cmis.elasticsearch`
 
@@ -1019,7 +1510,11 @@ _Default value:_ http://localhost:9200/
 
 Since Nuxeo 7.2\. To send the CMISQL queries to Elasticsearch, set to true.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.redis.enabled`
 
@@ -1027,35 +1522,57 @@ _Default value:_ false
 
 Set to true to activate Redis.
 
-_Default value:_ false
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.redis.host`
 
 **Since Nuxeo 5.8**
 
-_Default value:_ redishost
+**Default Value**
+
+`redishost`
+
+* * *
 
 #### `nuxeo.redis.port`
 
 **Since Nuxeo 5.8**
 
-_Default value:_ 6379
+**Default Value**
+
+`6379`
+
+* * *
 
 #### `nuxeo.redis.password`
 
 **Since Nuxeo 5.8**
 
+* * *
+
 #### `nuxeo.redis.database`
 
 **Since Nuxeo 5.8**
 
-_Default value:_ 0
+**Default Value**
+
+`0`
+
+* * *
 
 #### `nuxeo.redis.timeout`
 
 **Since Nuxeo 5.8**
 
-_Default value:_ 2000
+**Default Value**
+
+`2000`
+
+* * *
 
 #### `nuxeo.redis.maxTotal`
 
@@ -1063,7 +1580,11 @@ _Default value:_ 2000
 
 The maximum size of the Redis connections pool.
 
-_Default value:_ 16
+**Default Value**
+
+`16`
+
+* * *
 
 #### `nuxeo.redis.maxIdle`
 
@@ -1071,7 +1592,11 @@ _Default value:_ 16
 
 The maximum number of Redis idle connections in the pool.
 
-_Default value:_ 8
+**Default Value**
+
+`8`
+
+* * *
 
 #### `nuxeo.redis.prefix`
 
@@ -1079,7 +1604,11 @@ _Default value:_ 8
 
 This allows you to use a single Redis server between several Nuxeo cluster installations by having a different prefix for each cluster. See the page [Redis Configuration]({{page page='redis-configuration'}}) for more details.
 
-_Default value:_ nuxeo:
+**Default Value**
+
+`nuxeo:`
+
+* * *
 
 #### `server.crypt.secretkey`
 
@@ -1087,7 +1616,11 @@ _Default value:_ nuxeo:
 
 Custom secret key used for sensitive configuration data encryption. It takes either a raw value or an URL (e.g. <a class="external-link" rel="nofollow">file:///path/to/secretkey</a> or [http://some.online.file.com](http://some.online.file.com)).
 
-_Default value:_ `${server.status.key}`
+**Default Value**
+
+`${server.status.key}`
+
+* * *
 
 #### `server.crypt.keystore.path`
 
@@ -1095,7 +1628,11 @@ _Default value:_ `${server.status.key}`
 
 Path to the keystore to use for sensitive configuration data encryption.
 
-_Default value:_ `${javax.net.ssl.keyStore}`
+**Default Value**
+
+`${javax.net.ssl.keyStore}`
+
+* * *
 
 #### `server.crypt.keystore.pass`
 
@@ -1103,13 +1640,19 @@ _Default value:_ `${javax.net.ssl.keyStore}`
 
 The password used to protect the integrity of the keystore contents.
 
-_Default value:_ `${javax.net.ssl.keyStorePassword:="changeit"}`
+**Default Value**
+
+`${javax.net.ssl.keyStorePassword:="changeit"}`
+
+* * *
 
 #### `server.crypt.keyalias`
 
 **Since Nuxeo 7.4**
 
 The alias prefix where to retrieve the secret key from the keystore. It is automatically suffixed with the algorithm ("AES" or "DES").
+
+* * *
 
 #### `nuxeo.virtual.host`
 
@@ -1119,13 +1662,19 @@ This parameter can be used to replace the nuxeo-virtual-host request header (usu
 The use of the header is still preferred as the parameter forces your Nuxeo instance to be accessible from one URL only.<br/>
 Example: https://my.nuxeo.com/
 
+* * *
+
 #### `elasticsearch.enabled`
 
 **Since 6.0**
 
 Switch to enable/disable Elasticsearch usage
 
-_Default value:_ `true`
+**Default Value**
+
+`true`
+
+* * *
 
 #### `elasticsearch.client`
 
@@ -1133,13 +1682,21 @@ _Default value:_ `true`
 
 Choose between TransportClient and RestClient protocols
 
-_Default value:_ `TransportClient`
+**Default Value**
+
+`TransportClient`
+
+* * *
 
 #### `elasticsearch.indexName`
 
 Name of the Elasticsearch index for the default document repository
 
-_Default value:_ `nuxeo`
+**Default Value**
+
+`nuxeo`
+
+* * *
 
 #### `elasticsearch.addressList`
 
@@ -1150,73 +1707,121 @@ For RestClient protocol a comma separated list of URL. If empty an in JVM embedd
 
 Name of the Elasticsearch cluster to join when using a TranportClient protocol
 
-_Default value:_ `nuxeoCluster`
+**Default Value**
+
+`nuxeoCluster`
+
+* * *
 
 #### `elasticsearch.indexNumberOfReplicas`
 
 Number of replicas (not for local node)
 
-_Default value:_ `1`
+**Default Value**
+
+`1`
+
+* * *
 
 #### `elasticsearch.indexNumberOfShards`
 
 Number of shards (not for local node)
 
-_Default value:_ `5`
+**Default Value**
+
+`5`
+
+* * *
 
 #### `elasticsearch.nodeName`
 
 Name of the local node
 
-_Default value:_ `nuxeoNode`
+**Default Value**
+
+`nuxeoNode`
+
+* * *
 
 #### `elasticsearch.httpEnabled`
 
 Does the local node accept HTTP request on port 9200
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `elasticsearch.override.pageproviders`
 
 Comma separated list of CorePageProvider names to supersede by Elasticsearch
 
-_Default value:_ `default_search,DEFAULT_DOCUMENT_SUGGESTION`
+**Default Value**
+
+`default_search,DEFAULT_DOCUMENT_SUGGESTION`
+
+* * *
 
 #### `elasticsearch.reindex.bucketReadSize`
 
 Reindexing option, number of documents to process per worker
 
-_Default value:_ `500`
+**Default Value**
+
+`500`
+
+* * *
 
 #### `elasticsearch.reindex.bucketWriteSize`
 
 Reindexing option, number of documents to submit to Elasticsearch per bulk command
 
-_Default value:_ `50`
+**Default Value**
+
+`50`
+
+* * *
 
 #### `elasticsearch.indexing.maxThreads`
 
 Maximum size of the indexing thread pool
 
-_Default value:_ `4`
+**Default Value**
+
+`4`
+
+* * *
 
 #### `elasticsearch.indexing.clearCompletedAfterSeconds`
 
 Time to keep the completed indexing worker states
 
-_Default value:_ `90`
+**Default Value**
+
+`90`
+
+* * *
 
 #### `elasticsearch.adminCenter.displayClusterInfo`
 
 Display Elasticsearch cluster and nodes information in the admin center @since 6.0-HF06, always true for embedded mode
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `elasticsearch.reindex.onStartup`
 
 Reindex the repository content on startup if the index is empty
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `elasticsearch.restClient.connectionTimeoutMs`
 
@@ -1224,7 +1829,11 @@ _Default value:_ `false`
 
 A timeout in milliseconds until a connection is established
 
-_Default value:_ `5000`
+**Default Value**
+
+`5000`
+
+* * *
 
 #### `elasticsearch.restClient.socketTimeoutMs`
 
@@ -1232,7 +1841,11 @@ _Default value:_ `5000`
 
 A maximum period, in milliseconds, of inactivity between two consecutive data packets
 
-_Default value:_ `20000`
+**Default Value**
+
+`20000`
+
+* * *
 
 #### `elasticsearch.restClient.username`
 
@@ -1240,11 +1853,15 @@ _Default value:_ `20000`
 
 A username for client basic authentication
 
+* * *
+
 #### `elasticsearch.restClient.password`
 
 **Since 9.10-HF01**
 
 A password for client basic authentication
+
+* * *
 
 #### `elasticsearch.restClient.keystorePath`
 
@@ -1252,11 +1869,15 @@ A password for client basic authentication
 
 A path to a valid keystore
 
+* * *
+
 #### `elasticsearch.restClient.keystorePassword`
 
 **Since 9.10-HF01**
 
 The keystore password
+
+* * *
 
 #### `elasticsearch.restClient.keystoreType`
 
@@ -1264,7 +1885,11 @@ The keystore password
 
 The type of keystore, e.g. jks
 
-_Default value:_ Default Java system keystore type
+**Default Value**
+
+Default Java system keystore type
+
+* * *
 
 #### `elasticsearch.index.translog.durability`
 
@@ -1272,7 +1897,11 @@ _Default value:_ Default Java system keystore type
 
 The translog durability for Elasticsearch indexes. To reduce disk IO and increase performance this can be tuned to `async`.
 
-_Default value:_ `request`
+**Default Value**
+
+`request`
+
+* * *
 
 #### `nuxeo.directory.type`
 
@@ -1280,7 +1909,11 @@ _Default value:_ `request`
 
 Type of directory, used for LDAP or multi-directory configuration. Possible values are `default`, `ldap`, `multi`.
 
-_Default value:_ `default`
+**Default Value**
+
+`default`
+
+* * *
 
 #### `nuxeo.user.anonymous.enable`
 
@@ -1288,7 +1921,11 @@ _Default value:_ `default`
 
 When LDAP is enabled and this parameter is set to `true`, allows anonymous login with `Guest` user
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.user.emergency.enable`
 
@@ -1296,7 +1933,11 @@ _Default value:_ `false`
 
 When LDAP is enabled and this parameter is set to `true`, declares an emergency user to connect to Nuxeo in case of LDAP issues
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.user.emergency.username`
 
@@ -1304,7 +1945,11 @@ _Default value:_ `false`
 
 The username of emergency user when `nuxeo.user.emergency.enable` is set to `true`
 
-_Default value:_ `MyAdministrator`
+**Default Value**
+
+`MyAdministrator`
+
+* * *
 
 #### `nuxeo.user.emergency.password`
 
@@ -1312,7 +1957,11 @@ _Default value:_ `MyAdministrator`
 
 The password of emergency user when `nuxeo.user.emergency.enable` is set to `true`
 
-_Default value:_ `secret`
+**Default Value**
+
+`secret`
+
+* * *
 
 #### `nuxeo.user.emergency.firstname`
 
@@ -1320,11 +1969,15 @@ _Default value:_ `secret`
 
 The firstname of emergency user when `nuxeo.user.emergency.enable` is set to `true`
 
+* * *
+
 #### `nuxeo.user.emergency.lastname`
 
 **Since 6.0**
 
 The lastname of emergency user when `nuxeo.user.emergency.enable` is set to `true`
+
+* * *
 
 #### `nuxeo.picture.migration.enabled`
 
@@ -1332,7 +1985,11 @@ The lastname of emergency user when `nuxeo.user.emergency.enable` is set to `tru
 
 When set to `false` allows to disable the picture migration that is run on startup and that can be slow on big volume.
 
-_Default value:_ `true`
+**Default Value**
+
+`true`
+
+* * *
 
 #### `nuxeo.dbs.cache.enabled`
 
@@ -1340,7 +1997,11 @@ _Default value:_ `true`
 
 Whether or not the cache is enabled
 
-_Default value:_ `true`
+**Default Value**
+
+`true`
+
+* * *
 
 #### `nuxeo.dbs.cache.concurrencyLevel`
 
@@ -1348,7 +2009,11 @@ _Default value:_ `true`
 
 Guava cache parameter: Guides the allowed concurrency among update operations. Used as a hint for internal sizing. The table is internally partitioned to try to permit the indicated number of concurrent updates without contention. Because assignment of entries to these partitions is not necessarily uniform, the actual concurrency observed may vary. Ideally, you should choose a value to accommodate as many threads as will ever concurrently modify the table. Using a significantly higher value than you need can waste space and time, and a significantly lower value can lead to thread contention. But overestimates and underestimates within an order of magnitude do not usually have much noticeable impact. A value of one permits only one thread to modify the cache at a time, but since read operations and cache loading computations can proceed concurrently, this still yields higher concurrency than full synchronization.
 
-_Default value:_ `10`
+**Default Value**
+
+`10`
+
+* * *
 
 #### `nuxeo.dbs.cache.maxSize`
 
@@ -1356,7 +2021,11 @@ _Default value:_ `10`
 
 The maximum size of DBS cache
 
-_Default value:_ `1000`
+**Default Value**
+
+`1000`
+
+* * *
 
 #### `nuxeo.dbs.cache.ttl`
 
@@ -1364,7 +2033,11 @@ _Default value:_ `1000`
 
 The expire after write value in minutes
 
-_Default value:_ `10`
+**Default Value**
+
+`10`
+
+* * *
 
 #### `kafka.enabled`
 
@@ -1372,7 +2045,11 @@ _Default value:_ `10`
 
 Switch the default Stream configuration to Apache Kafka
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `kafka.zkServers`
 
@@ -1380,7 +2057,11 @@ _Default value:_ `false`
 
 Deprecated since 10.2, 9.10-HF04, Nuxeo don't need Zookeeper access
 
-_Default value:_ `localhost:2181`
+**Default Value**
+
+`localhost:2181`
+
+* * *
 
 #### `kafka.bootstrap.servers`
 
@@ -1388,7 +2069,11 @@ _Default value:_ `localhost:2181`
 
 host:port comma separated list of Kafka Brokers
 
-_Default value:_ `localhost:9092`
+**Default Value**
+
+`localhost:9092`
+
+* * *
 
 #### `kafka.default.replication.factor`
 
@@ -1396,7 +2081,11 @@ _Default value:_ `localhost:9092`
 
 Default replication factor per partition when creating a new Topic
 
-_Default value:_ `1`
+**Default Value**
+
+`1`
+
+* * *
 
 #### `kafka.topicPrefix`
 
@@ -1404,7 +2093,11 @@ _Default value:_ `1`
 
 The prefix applied to any Kafka Topic
 
-_Default value:_ `nuxeo-`
+**Default Value**
+
+`nuxeo-`
+
+* * *
 
 #### `kafka.request.timeout.ms`
 
@@ -1412,7 +2105,11 @@ _Default value:_ `nuxeo-`
 
 Request timeout between Nuxeo and a Kafka broker
 
-_Default value:_ `30000`
+**Default Value**
+
+`30000`
+
+* * *
 
 #### `kafka.default.api.timeout.ms`
 
@@ -1420,7 +2117,11 @@ _Default value:_ `30000`
 
 Default timeout for consumer API related to position
 
-_Default value:_ `120000`
+**Default Value**
+
+`120000`
+
+* * *
 
 #### `kafka.max.poll.interval.ms`
 
@@ -1428,7 +2129,11 @@ _Default value:_ `120000`
 
 Maximum delay between poll invocation
 
-_Default value:_ `7200000`
+**Default Value**
+
+`7200000`
+
+* * *
 
 #### `kafka.max.poll.records`
 
@@ -1436,7 +2141,11 @@ _Default value:_ `7200000`
 
 Maximum number of records to read per poll
 
-_Default value:_ `2`
+**Default Value**
+
+`2`
+
+* * *
 
 #### `kafka.session.timeout.ms`
 
@@ -1444,7 +2153,11 @@ _Default value:_ `2`
 
 Consumers that don't send heartbeat during this delay are removed from the group
 
-_Default value:_ `50000`
+**Default Value**
+
+`50000`
+
+* * *
 
 #### `kafka.heartbeat.interval.ms`
 
@@ -1452,7 +2165,11 @@ _Default value:_ `50000`
 
 Heartbeat interval
 
-_Default value:_ `4000`
+**Default Value**
+
+`4000`
+
+* * *
 
 #### `kafka.delivery.timeout.ms`
 
@@ -1460,7 +2177,11 @@ _Default value:_ `4000`
 
 Timeout for a producer to get an acknowledgement
 
-_Default value:_ `120000`
+**Default Value**
+
+`120000`
+
+* * *
 
 #### `kafka.acks`
 
@@ -1468,7 +2189,11 @@ _Default value:_ `120000`
 
 The number of acknowledgments expected by a producer
 
-_Default value:_ `1`
+**Default Value**
+
+`1`
+
+* * *
 
 #### `kafka.sasl.enabled`
 
@@ -1476,7 +2201,11 @@ _Default value:_ `1`
 
 Enable SASL authentication to communicate with Kafka brokers
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `kafka.security.protocol`
 
@@ -1484,7 +2213,11 @@ _Default value:_ `false`
 
 When using SASL authentication, choose the protocol to communicate with brokers, valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
 
-_Default value:_ `SASL_PLAINTEXT`
+**Default Value**
+
+`SASL_PLAINTEXT`
+
+* * *
 
 #### `kafka.sasl.mechanism`
 
@@ -1492,7 +2225,11 @@ _Default value:_ `SASL_PLAINTEXT`
 
 SASL mechanism used for client connections
 
-_Default value:_ `SCRAM-SHA-256`
+**Default Value**
+
+`SCRAM-SHA-256`
+
+* * *
 
 #### `kafka.sasl.jaas.config`
 
@@ -1500,7 +2237,7 @@ _Default value:_ `SCRAM-SHA-256`
 
 JAAS login context parameters for SASL connections in the format used by JAAS configuration files. See [Kafka documentation for more information](https://kafka.apache.org/documentation/#security_sasl_scram_clientconfig).
 
-_Default value:_
+* * *
 
 #### `kafka.ssl`
 
@@ -1508,15 +2245,19 @@ _Default value:_
 
 Use SSL to communicate with Kafka Broker
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `kafka.truststore.path`
 
 **Since 10.3/9.10-HF22**
 
-The location of the trust store file, empty path means no truststore
+The location of the trust store file, empty path means no truststore.
 
-_Default value:_
+* * *
 
 #### `kafka.truststore.type`
 
@@ -1524,23 +2265,27 @@ _Default value:_
 
 The file format of the trust store file
 
-_Default value:_ `JKS`
+**Default Value**
+
+`JKS`
+
+* * *
 
 #### `kafka.truststore.password`
 
 **Since 10.3/9.10-HF22**
 
-The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled
+The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.
 
-_Default value:_
+* * *
 
 #### `kafka.keystore.path`
 
 **Since 10.3/9.10-HF22**
 
-The location of the key store file used by the client for two-way authentication, empty value means no keystore
+The location of the key store file used by the client for two-way authentication, empty value means no keystore.
 
-_Default value:_
+* * *
 
 #### `kafka.keystore.type`
 
@@ -1548,7 +2293,11 @@ _Default value:_
 
 The file format of the key store file
 
-_Default value:_ `JKS`
+**Default Value**
+
+`JKS`
+
+* * *
 
 #### `kafka.keystore.password`
 
@@ -1556,7 +2305,7 @@ _Default value:_ `JKS`
 
 The store password for the key store file
 
-_Default value:_
+* * *
 
 #### `nuxeo.stream.chronicle.dir`
 
@@ -1564,7 +2313,11 @@ _Default value:_
 
 The directory where Chronicle Queue files are stored.
 
-_Default value:_ `${nuxeo.data.dir}/data/stream`
+**Default Value**
+
+`${nuxeo.data.dir}/data/stream`
+
+* * *
 
 #### `nuxeo.stream.chronicle.retention.duration`
 
@@ -1572,7 +2325,11 @@ _Default value:_ `${nuxeo.data.dir}/data/stream`
 
 Default retention for Chronicle Queue Log, default to 4 days.
 
-_Default value:_ `4d`
+**Default Value**
+
+`4d`
+
+* * *
 
 #### `nuxeo.stream.audit.enabled`
 
@@ -1580,7 +2337,11 @@ _Default value:_ `4d`
 
 Enable the Nuxeo Stream Audit Writer implementation
 
-_Default value:_ `true`
+**Default Value**
+
+`true`
+
+* * *
 
 #### `nuxeo.stream.audit.log.config`
 
@@ -1588,7 +2349,11 @@ _Default value:_ `true`
 
 The Log configuration to use for the Stream Audit Writer
 
-_Default value:_ `audit`
+**Default Value**
+
+`audit`
+
+* * *
 
 #### `nuxeo.stream.audit.batch.size`
 
@@ -1596,7 +2361,11 @@ _Default value:_ `audit`
 
 The entries batch size to submit the the audit backend
 
-_Default value:_ `25`
+**Default Value**
+
+`25`
+
+* * *
 
 #### `nuxeo.stream.audit.batch.threshold.ms`
 
@@ -1604,7 +2373,11 @@ _Default value:_ `25`
 
 Do not wait more than this threshold if the batch is not full
 
-_Default value:_ `500`
+**Default Value**
+
+`500`
+
+* * *
 
 #### `nuxeo.stream.work.enabled`
 
@@ -1612,7 +2385,11 @@ _Default value:_ `500`
 
 Supersed the default WorkManager with the Sream WorkManager
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.stream.work.log.config`
 
@@ -1620,7 +2397,11 @@ _Default value:_ `false`
 
 The Log configuration to use for the Stream WorkManager
 
-_Default value:_ `work`
+**Default Value**
+
+`work`
+
+* * *
 
 #### `nuxeo.stream.work.over.provisioning.factor`
 
@@ -1628,7 +2409,11 @@ _Default value:_ `work`
 
 The factor to use on the Work Thread pool size to get the number of Log partition.
 
-_Default value:_ `3`
+**Default Value**
+
+`3`
+
+* * *
 
 #### `nuxeo.stream.work.computation.filter.enabled`
 
@@ -1636,7 +2421,11 @@ _Default value:_ `3`
 
 Filter work with a serialized size that exceed a threshold so they are stored outside of the stream.
 
-_Default value:_ `false`
+**Default Value**
+
+`false`
+
+* * *
 
 #### `nuxeo.stream.work.computation.filter.thresholdSize`
 
@@ -1644,7 +2433,11 @@ _Default value:_ `false`
 
 Threshold in bytes that is used to store work outside of the stream.
 
-_Default value:_ `1000000`
+**Default Value**
+
+`1000000`
+
+* * *
 
 #### `nuxeo.stream.work.computation.filter.class`
 
@@ -1652,7 +2445,11 @@ _Default value:_ `1000000`
 
 The class that implement the external storage of large work. Default is using a Transient store, there is also a KeyValue implementation `org.nuxeo.ecm.core.work.KeyValueStoreOverflowRecordFilter`.
 
-_Default value:_ `org.nuxeo.ecm.core.transientstore.computation.TransientStoreOverflowRecordFilter`
+**Default Value**
+
+`org.nuxeo.ecm.core.transientstore.computation.TransientStoreOverflowRecordFilter`
+
+* * *
 
 #### `nuxeo.stream.work.computation.filter.storeName`
 
@@ -1660,7 +2457,11 @@ _Default value:_ `org.nuxeo.ecm.core.transientstore.computation.TransientStoreOv
 
 The storage name to use.
 
-_Default value:_ `default`
+**Default Value**
+
+`default`
+
+* * *
 
 #### `nuxeo.stream.work.computation.filter.storeKeyPrefix`
 
@@ -1668,7 +2469,11 @@ _Default value:_ `default`
 
 A key prefix to use on the external storage.
 
-_Default value:_ `bigRecord:`
+**Default Value**
+
+`bigRecord:`
+
+* * *
 
 #### `nuxeo.stream.work.computation.filter.storeTTL`
 
@@ -1677,7 +2482,11 @@ _Default value:_ `bigRecord:`
 The time to live used the KeyValue storage implementation.
 This does not apply to the Transient store where the retention is fixed by its configuration.
 
-_Default value:_ `4d`
+**Default Value**
+
+`4d`
+
+* * *
 
 #### `org.nuxeo.runtime.reload_strategy`
 
@@ -1691,16 +2500,22 @@ There're two possible values, changing slightly the before/after reload logic:
 <li>`restart`: components are stopped, then de-activated, new/former components are deployed/undeployed, components are activated, then started</li>
 </ul>
 
-_Default value:_ `standby`
+**Default Value**
 
-<div class="row" data-equalizer data-equalize-on="medium"><div class="column medium-6">{{#> panel heading='Related content'}}
+`standby`
 
+* * *
+
+<div class="row" data-equalizer data-equalize-on="medium">
+<div class="column medium-6">
+
+{{#> panel heading='Related content'}}
 - [Setup Best Practices]({{page page='setup-best-practices'}})
-
 - [Nuxeo Clustering Configuration]({{page page='nuxeo-clustering-configuration'}})
+{{/panel}}
+</div>
 
-{{/panel}}</div><div class="column medium-6">
-
+<div class="column medium-6">
 &nbsp;
-
-</div></div>
+</div>
+</div>

--- a/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
@@ -1,1078 +1,42 @@
 ---
 title: Configuration Parameters Index (nuxeo.conf)
 review:
-    comment: ''
-    date: '2017-12-11'
-    status: ok
+  comment: ''
+  date: '2017-12-11'
+  status: ok
 labels:
-    - content-review-lts2016
-    - nuxeo_conf
-    - properties
-    - templates
-    - launcher
-    - akervern
-    - multiexcerpt
-    - lts2017-ok
+  - content-review-lts2016
+  - nuxeo_conf
+  - properties
+  - templates
+  - launcher
+  - akervern
+  - multiexcerpt
+  - lts2017-ok
 confluence:
-    ajs-parent-page-id: '31032113'
-    ajs-parent-page-title: Administration
-    ajs-space-key: NXDOC
-    ajs-space-name: Nuxeo Platform Developer Documentation
-    canonical: viewpage.action?pageId=3866689
-    canonical_source: viewpage.action?pageId=3866689
-    page_id: '3866689'
-    shortlink: QQA7
-    shortlink_source: 'https://doc.nuxeo.com/x/QQA7'
-    source_link: /pages/viewpage.action?pageId=3866689
+  ajs-parent-page-id: '31032113'
+  ajs-parent-page-title: Administration
+  ajs-space-key: NXDOC
+  ajs-space-name: Nuxeo Platform Developer Documentation
+  canonical: viewpage.action?pageId=3866689
+  canonical_source: viewpage.action?pageId=3866689
+  page_id: '3866689'
+  shortlink: QQA7
+  shortlink_source: 'https://doc.nuxeo.com/x/QQA7'
+  source_link: /pages/viewpage.action?pageId=3866689
 tree_item_index: 100
 toc: true
 version_override:
-    LTS 2015: 710/admindoc/configuration-parameters-index-nuxeoconf
-    '6.0': 60/admindoc/configuration-parameters-index-nuxeoconf
-    '5.8': 58/admindoc/configuration-parameters-index-nuxeoconf
-history:
-    -
-        author: Ronan Daniellou
-        date: '2016-08-22 13:50'
-        message: 'eeps only FT value for "nuxeo.db.idle-timeout-minutes'
-        version: '207'
-    -
-        author: Ronan Daniellou
-        date: '2016-08-22 13:31'
-        message: Formatting.
-        version: '206'
-    -
-        author: Ronan Daniellou
-        date: '2016-08-22 13:28'
-        message: 'Adds "nuxeo.db.idle-timeout-minutes" property.'
-        version: '205'
-    -
-        author: Ronan Daniellou
-        date: '2016-08-17 08:17'
-        message: 'Adds "nuxeo.db.idle-timeout-minutes" property.'
-        version: '204'
-    -
-        author: Florent Guillaume
-        date: '2016-08-16 15:02'
-        message: Removed nuxeo.db.embeddedDatasources
-        version: '203'
-    -
-        author: Bertrand Chauvin
-        date: '2016-08-11 10:42'
-        message: Fix formulation
-        version: '202'
-    -
-        author: Bertrand Chauvin
-        date: '2016-08-11 10:36'
-        message: Fix typo
-        version: '201'
-    -
-        author: Frantz Fischer
-        date: '2016-06-17 15:51'
-        message: ''
-        version: '200'
-    -
-        author: Solen Guitter
-        date: '2016-06-03 08:08'
-        message: Remove properties set from Configuration service
-        version: '199'
-    -
-        author: Solen Guitter
-        date: '2016-04-22 15:42'
-        message: Update description repository.clustering.invalidation
-        version: '198'
-    -
-        author: Solen Guitter
-        date: '2016-04-22 14:42'
-        message: Add repository.clustering.invalidation
-        version: '197'
-    -
-        author: Solen Guitter
-        date: '2016-03-29 15:22'
-        message: Add some details on repository.clustering.id
-        version: '196'
-    -
-        author: Manon Lumeau
-        date: '2016-03-25 10:43'
-        message: ''
-        version: '195'
-    -
-        author: Manon Lumeau
-        date: '2016-03-25 10:41'
-        message: ''
-        version: '194'
-    -
-        author: Alain Escaffre
-        date: '2016-03-23 22:52'
-        message: ''
-        version: '193'
-    -
-        author: Alain Escaffre
-        date: '2016-03-23 22:47'
-        message: ''
-        version: '192'
-    -
-        author: Manon Lumeau
-        date: '2016-03-23 16:50'
-        message: ''
-        version: '191'
-    -
-        author: Manon Lumeau
-        date: '2016-03-23 14:04'
-        message: ''
-        version: '190'
-    -
-        author: Alain Escaffre
-        date: '2016-03-23 13:46'
-        message: ''
-        version: '189'
-    -
-        author: Alain Escaffre
-        date: '2016-03-23 13:29'
-        message: ''
-        version: '188'
-    -
-        author: Alain Escaffre
-        date: '2016-03-23 13:17'
-        message: ''
-        version: '187'
-    -
-        author: Alain Escaffre
-        date: '2016-03-23 11:15'
-        message: ''
-        version: '186'
-    -
-        author: Benoit Delbosc
-        date: '2016-02-02 10:48'
-        message: ''
-        version: '185'
-    -
-        author: Benoit Delbosc
-        date: '2016-02-02 10:47'
-        message: Add redis pool options
-        version: '184'
-    -
-        author: Arnaud Kervern
-        date: '2016-01-29 13:32'
-        message: audit.elasticsearch.enabled
-        version: '183'
-    -
-        author: Solen Guitter
-        date: '2016-01-28 14:13'
-        message: ''
-        version: '182'
-    -
-        author: Solen Guitter
-        date: '2015-12-15 10:24'
-        message: Mark org.nuxeo.ecm.webapp.dashboard.mode as deprecated
-        version: '181'
-    -
-        author: Solen Guitter
-        date: '2015-12-15 10:18'
-        message: Add deprecation on opensocial.gadgets.host and opensocial.gadgets.port
-        version: '180'
-    -
-        author: Solen Guitter
-        date: '2015-12-15 09:47'
-        message: ''
-        version: '179'
-    -
-        author: Florent Guillaume
-        date: '2015-12-02 12:16'
-        message: nuxeo.vcs.ddlmode
-        version: '178'
-    -
-        author: Solen Guitter
-        date: '2015-12-01 16:29'
-        message: ''
-        version: '177'
-    -
-        author: Solen Guitter
-        date: '2015-11-27 15:37'
-        message: 'NXDOC-658: Marketplace packages are now called Nuxeo Packages'
-        version: '176'
-    -
-        author: Julien Carsique
-        date: '2015-11-18 16:01'
-        message: ''
-        version: '175'
-    -
-        author: Thierry Martins
-        date: '2015-11-13 14:47'
-        message: ''
-        version: '174'
-    -
-        author: Thierry Martins
-        date: '2015-11-13 14:45'
-        message: ''
-        version: '173'
-    -
-        author: Julien Carsique
-        date: '2015-10-20 12:10'
-        message: ''
-        version: '172'
-    -
-        author: Julien Carsique
-        date: '2015-10-19 16:08'
-        message: ''
-        version: '171'
-    -
-        author: Antoine Taillefer
-        date: '2015-10-05 07:49'
-        message: ''
-        version: '170'
-    -
-        author: Antoine Taillefer
-        date: '2015-10-05 07:49'
-        message: ''
-        version: '169'
-    -
-        author: Benoit Delbosc
-        date: '2015-09-22 11:25'
-        message: Add elasticsearch nuxeo conf parameters
-        version: '168'
-    -
-        author: Mathieu Guillaume
-        date: '2015-09-18 08:06'
-        message: ''
-        version: '167'
-    -
-        author: Julien Carsique
-        date: '2015-09-15 09:41'
-        message: nuxeo.tmp.dir
-        version: '166'
-    -
-        author: Julien Carsique
-        date: '2015-08-24 14:39'
-        message: ''
-        version: '165'
-    -
-        author: Julien Carsique
-        date: '2015-08-24 14:29'
-        message: ''
-        version: '164'
-    -
-        author: Solen Guitter
-        date: '2015-07-03 08:43'
-        message: ''
-        version: '163'
-    -
-        author: Solen Guitter
-        date: '2015-07-03 08:43'
-        message: ''
-        version: '162'
-    -
-        author: Solen Guitter
-        date: '2015-07-03 08:16'
-        message: 'Added "since" column'
-        version: '161'
-    -
-        author: Solen Guitter
-        date: '2015-07-02 15:33'
-        message: ''
-        version: '160'
-    -
-        author: Solen Guitter
-        date: '2015-07-02 13:11'
-        message: 'NXP-16197: Update default value and description of zip.entry.encoding'
-        version: '159'
-    -
-        author: Antoine Taillefer
-        date: '2015-07-01 08:32'
-        message: ''
-        version: '158'
-    -
-        author: Antoine Taillefer
-        date: '2015-06-30 15:47'
-        message: ''
-        version: '157'
-    -
-        author: Florent Guillaume
-        date: '2015-06-02 08:52'
-        message: Added repository.clustering.id
-        version: '156'
-    -
-        author: Julien Carsique
-        date: '2015-05-27 10:02'
-        message: nuxeo.vcs.fulltext.analyzer.language
-        version: '155'
-    -
-        author: Julien Carsique
-        date: '2015-05-22 15:28'
-        message: add nuxeo.server.tomcat_admin.host
-        version: '154'
-    -
-        author: Benoit Delbosc
-        date: '2015-04-07 09:00'
-        message: ''
-        version: '153'
-    -
-        author: Benoit Delbosc
-        date: '2015-04-07 08:53'
-        message: add nuxeo.vcs.fulltext.search.disabled option
-        version: '152'
-    -
-        author: Solen Guitter
-        date: '2015-04-01 12:17'
-        message: ''
-        version: '151'
-    -
-        author: Solen Guitter
-        date: '2015-04-01 12:16'
-        message: ''
-        version: '150'
-    -
-        author: Julien Carsique
-        date: '2015-03-11 14:11'
-        message: ''
-        version: '149'
-    -
-        author: Florent Guillaume
-        date: '2015-01-09 11:30'
-        message: cmis enableComplexProperties
-        version: '148'
-    -
-        author: Solen Guitter
-        date: '2014-11-26 14:31'
-        message: ''
-        version: '147'
-    -
-        author: Solen Guitter
-        date: '2014-11-26 14:18'
-        message: Formatting and link update
-        version: '146'
-    -
-        author: Guillaume Renard
-        date: '2014-10-31 11:33'
-        message: ''
-        version: '145'
-    -
-        author: Florent Guillaume
-        date: '2014-10-27 11:25'
-        message: ''
-        version: '144'
-    -
-        author: Mathieu Guillaume
-        date: '2014-10-22 11:12'
-        message: ''
-        version: '143'
-    -
-        author: Nelson Silva
-        date: '2014-10-06 09:52'
-        message: ''
-        version: '142'
-    -
-        author: Nelson Silva
-        date: '2014-10-01 18:56'
-        message: ''
-        version: '141'
-    -
-        author: Solen Guitter
-        date: '2014-09-22 10:20'
-        message: '5.9.6 -> 6.0'
-        version: '140'
-    -
-        author: Thomas Roger
-        date: '2014-09-18 14:02'
-        message: ''
-        version: '139'
-    -
-        author: Julien Carsique
-        date: '2014-09-16 14:08'
-        message: ''
-        version: '138'
-    -
-        author: Vladimir Pasquier
-        date: '2014-09-15 16:28'
-        message: ''
-        version: '137'
-    -
-        author: Vladimir Pasquier
-        date: '2014-09-15 14:54'
-        message: ''
-        version: '136'
-    -
-        author: Thomas Roger
-        date: '2014-09-03 18:12'
-        message: ''
-        version: '135'
-    -
-        author: Florent Guillaume
-        date: '2014-09-03 15:43'
-        message: ''
-        version: '134'
-    -
-        author: Solen Guitter
-        date: '2014-09-01 16:26'
-        message: Add filter on parameter
-        version: '133'
-    -
-        author: Stéphane Lacoin
-        date: '2014-08-26 10:25'
-        message: ''
-        version: '132'
-    -
-        author: Solen Guitter
-        date: '2014-08-21 11:05'
-        message: Removed 5.4 and 5.5 references
-        version: '131'
-    -
-        author: Vladimir Pasquier
-        date: '2014-08-20 23:52'
-        message: Add web exception extended mode
-        version: '130'
-    -
-        author: Solen Guitter
-        date: '2014-07-24 15:55'
-        message: format
-        version: '129'
-    -
-        author: Solen Guitter
-        date: '2014-06-26 09:56'
-        message: typo
-        version: '128'
-    -
-        author: Anahide Tchertchian
-        date: '2014-06-25 17:49'
-        message: 'NXP-14648: mention browser compatibility for ajaxified tabs feature'
-        version: '127'
-    -
-        author: Manon Lumeau
-        date: '2014-06-05 10:27'
-        message: ''
-        version: '126'
-    -
-        author: Julien Carsique
-        date: '2014-06-03 18:39'
-        message: 'NXP-8014: new property to manage MP directory'
-        version: '125'
-    -
-        author: Julien Carsique
-        date: '2014-06-03 11:17'
-        message: ''
-        version: '124'
-    -
-        author: Thibaud Arguillere
-        date: '2014-06-02 22:36'
-        message: ''
-        version: '123'
-    -
-        author: Vladimir Pasquier
-        date: '2014-05-12 16:38'
-        message: ''
-        version: '122'
-    -
-        author: Julien Carsique
-        date: '2014-03-22 14:28'
-        message: ''
-        version: '121'
-    -
-        author: Thierry Martins
-        date: '2014-03-04 10:11'
-        message: ''
-        version: '120'
-    -
-        author: Thierry Martins
-        date: '2014-03-04 10:10'
-        message: change property name
-        version: '119'
-    -
-        author: Julien Carsique
-        date: '2014-02-27 12:10'
-        message: 'Consistency writting: "Since Nuxeo x.y.z"'
-        version: '118'
-    -
-        author: Julien Carsique
-        date: '2014-02-26 14:25'
-        message: org.nuxeo.connect properties
-        version: '117'
-    -
-        author: Julien Carsique
-        date: '2014-02-26 14:10'
-        message: 'NXBT-727, NXBT-724, NXP-8024: add properties for proxy NTLM and proxy PAC'
-        version: '116'
-    -
-        author: Thierry Martins
-        date: '2014-02-12 13:54'
-        message: new property nuxeo.max.segment.size
-        version: '115'
-    -
-        author: Julien Carsique
-        date: '2014-02-10 14:29'
-        message: ''
-        version: '114'
-    -
-        author: Guillaume Renard
-        date: '2014-01-16 19:09'
-        message: Reverted from v. 111
-        version: '113'
-    -
-        author: Guillaume Renard
-        date: '2014-01-16 17:08'
-        message: ''
-        version: '112'
-    -
-        author: Solen Guitter
-        date: '2014-01-16 11:57'
-        message: Formatting
-        version: '111'
-    -
-        author: Benoit Delbosc
-        date: '2014-01-15 11:11'
-        message: Adding use-nulls-last-on-desc
-        version: '110'
-    -
-        author: Guillaume Renard
-        date: '2013-11-13 10:53'
-        message: ''
-        version: '109'
-    -
-        author: Florent Guillaume
-        date: '2013-11-12 19:16'
-        message: ''
-        version: '108'
-    -
-        author: Florent Guillaume
-        date: '2013-10-29 17:12'
-        message: 5.8 vcs config
-        version: '107'
-    -
-        author: Alain Escaffre
-        date: '2013-10-27 23:08'
-        message: ''
-        version: '106'
-    -
-        author: Guillaume Renard
-        date: '2013-10-25 19:30'
-        message: ''
-        version: '105'
-    -
-        author: Anahide Tchertchian
-        date: '2013-10-11 18:06'
-        message: 'NXP-9384: add nuxeo.jsf.useAjaxTabs'
-        version: '104'
-    -
-        author: Anahide Tchertchian
-        date: '2013-10-04 17:06'
-        message: ''
-        version: '103'
-    -
-        author: Guillaume Renard
-        date: '2013-09-23 19:07'
-        message: ''
-        version: '102'
-    -
-        author: Solen Guitter
-        date: '2013-09-20 17:43'
-        message: ''
-        version: '101'
-    -
-        author: Vladimir Pasquier
-        date: '2013-08-19 17:56'
-        message: ''
-        version: '100'
-    -
-        author: Thierry Martins
-        date: '2013-08-14 16:21'
-        message: update ignore chars default value
-        version: '99'
-    -
-        author: Solen Guitter
-        date: '2013-08-06 11:25'
-        message: ''
-        version: '98'
-    -
-        author: Solen Guitter
-        date: '2013-08-06 11:25'
-        message: Formatting
-        version: '97'
-    -
-        author: Vladimir Pasquier
-        date: '2013-08-05 15:26'
-        message: ''
-        version: '96'
-    -
-        author: Julien Carsique
-        date: '2013-08-02 16:16'
-        message: ''
-        version: '95'
-    -
-        author: Solen Guitter
-        date: '2013-08-01 15:30'
-        message: ''
-        version: '94'
-    -
-        author: Thomas Roger
-        date: '2013-07-24 14:14'
-        message: ''
-        version: '93'
-    -
-        author: Thomas Roger
-        date: '2013-07-24 14:09'
-        message: ''
-        version: '92'
-    -
-        author: Guillaume Renard
-        date: '2013-07-12 15:44'
-        message: Add nuxeo.jsf.numberOfConversationsInSession param description
-        version: '91'
-    -
-        author: Stéphane Lacoin
-        date: '2013-07-03 11:29'
-        message: ''
-        version: '90'
-    -
-        author: Solen Guitter
-        date: '2013-06-28 18:31'
-        message: Added Since 5.7.2 mention on nuxeo.jsf.numberOfViewsInSession and nuxeo.jsf.numberOfLogicalViews
-        version: '89'
-    -
-        author: Anahide Tchertchian
-        date: '2013-06-25 18:30'
-        message: 'NXP-11423: add parameters for JSF number of views configuration'
-        version: '88'
-    -
-        author: Solen Guitter
-        date: '2013-06-18 14:32'
-        message: Changed since 5.7 for 5.7.1
-        version: '87'
-    -
-        author: Anahide Tchertchian
-        date: '2013-06-17 15:00'
-        message: 'NXP-11129: change property name to studio.snapshot.disablePkgValidation'
-        version: '86'
-    -
-        author: Anahide Tchertchian
-        date: '2013-06-16 16:45'
-        message: 'NXP-11129: document property org.nuxeo.ecm.platform.disableStudioSnapshotPackageValidation'
-        version: '85'
-    -
-        author: Solen Guitter
-        date: '2013-02-18 16:51'
-        message: Added org.nuxeo.query.builder.ignored.chars parameter
-        version: '84'
-    -
-        author: Solen Guitter
-        date: '2013-01-04 12:03'
-        message: 'Added new 5.7 D&D parameters from 5.6 documentation'
-        version: '83'
-    -
-        author: Anahide Tchertchian
-        date: '2012-11-07 11:39'
-        message: ''
-        version: '82'
-    -
-        author: Anahide Tchertchian
-        date: '2012-11-07 11:39'
-        message: ''
-        version: '81'
-    -
-        author: Julien Carsique
-        date: '2012-11-06 14:33'
-        message: ''
-        version: '80'
-    -
-        author: Solen Guitter
-        date: '2012-07-05 16:53'
-        message: Migrated to Confluence 4.0
-        version: '79'
-    -
-        author: Solen Guitter
-        date: '2012-07-05 16:53'
-        message: ''
-        version: '78'
-    -
-        author: Anahide Tchertchian
-        date: '2012-06-20 16:55'
-        message: ''
-        version: '77'
-    -
-        author: Anahide Tchertchian
-        date: '2012-06-20 16:54'
-        message: ''
-        version: '76'
-    -
-        author: Stéphane Lacoin
-        date: '2012-05-15 10:00'
-        message: ''
-        version: '75'
-    -
-        author: Stéphane Lacoin
-        date: '2012-05-15 09:22'
-        message: ''
-        version: '74'
-    -
-        author: Solen Guitter
-        date: '2012-05-10 16:21'
-        message: ''
-        version: '73'
-    -
-        author: Julien Carsique
-        date: '2012-04-23 18:25'
-        message: ''
-        version: '72'
-    -
-        author: Julien Carsique
-        date: '2012-04-23 18:24'
-        message: follow changes from NXP-9251
-        version: '71'
-    -
-        author: Arnaud Kervern
-        date: '2012-04-11 14:33'
-        message: ''
-        version: '70'
-    -
-        author: Anahide Tchertchian
-        date: '2012-03-26 15:47'
-        message: ''
-        version: '69'
-    -
-        author: Anahide Tchertchian
-        date: '2012-03-26 15:45'
-        message: ''
-        version: '68'
-    -
-        author: Anahide Tchertchian
-        date: '2012-03-26 12:37'
-        message: ''
-        version: '67'
-    -
-        author: stan
-        date: '2012-03-24 19:36'
-        message: ''
-        version: '66'
-    -
-        author: Julien Carsique
-        date: '2012-02-29 11:52'
-        message: ''
-        version: '65'
-    -
-        author: Florent Guillaume
-        date: '2012-02-02 14:03'
-        message: ''
-        version: '64'
-    -
-        author: Solen Guitter
-        date: '2011-12-10 00:04'
-        message: ''
-        version: '63'
-    -
-        author: Mathieu Guillaume
-        date: '2011-11-29 13:17'
-        message: 'Change title so the page is found when searching for "nuxeo.conf"'
-        version: '62'
-    -
-        author: Thierry Delprat
-        date: '2011-11-25 15:13'
-        message: ''
-        version: '61'
-    -
-        author: Thierry Delprat
-        date: '2011-11-25 14:51'
-        message: ''
-        version: '60'
-    -
-        author: Stéphane Lacoin
-        date: '2011-11-23 10:45'
-        message: ''
-        version: '59'
-    -
-        author: Stéphane Lacoin
-        date: '2011-11-23 10:44'
-        message: ''
-        version: '58'
-    -
-        author: Stéphane Lacoin
-        date: '2011-11-22 17:52'
-        message: ''
-        version: '57'
-    -
-        author: Anahide Tchertchian
-        date: '2011-11-22 12:05'
-        message: ''
-        version: '56'
-    -
-        author: Florent Guillaume
-        date: '2011-11-22 12:03'
-        message: Added nuxeo.db.jdbc.url and nuxeo.db.validationQuery
-        version: '55'
-    -
-        author: Thierry Delprat
-        date: '2011-11-16 17:53'
-        message: ''
-        version: '54'
-    -
-        author: Julien Carsique
-        date: '2011-10-27 16:31'
-        message: ''
-        version: '53'
-    -
-        author: Mathieu Guillaume
-        date: '2011-10-25 20:56'
-        message: Added to options and changed 5.4.3 into 5.5
-        version: '52'
-    -
-        author: Mathieu Guillaume
-        date: '2011-10-09 14:52'
-        message: Added launcher.stop.max.wait parameter
-        version: '51'
-    -
-        author: Julien Carsique
-        date: '2011-08-11 17:24'
-        message: NXP-5291 - added session.timeout parameter
-        version: '50'
-    -
-        author: Julien Carsique
-        date: '2011-08-04 18:38'
-        message: ''
-        version: '49'
-    -
-        author: Julien Carsique
-        date: '2011-08-01 14:42'
-        message: add server.status.key param
-        version: '48'
-    -
-        author: Vladimir Pasquier
-        date: '2011-07-13 17:52'
-        message: ''
-        version: '47'
-    -
-        author: Vladimir Pasquier
-        date: '2011-07-13 17:46'
-        message: ''
-        version: '46'
-    -
-        author: Julien Carsique
-        date: '2011-06-21 19:04'
-        message: ''
-        version: '45'
-    -
-        author: Julien Carsique
-        date: '2011-06-21 19:03'
-        message: ''
-        version: '44'
-    -
-        author: Julien Carsique
-        date: '2011-06-21 19:02'
-        message: ''
-        version: '43'
-    -
-        author: Julien Carsique
-        date: '2011-06-21 16:45'
-        message: ''
-        version: '42'
-    -
-        author: Julien Carsique
-        date: '2011-06-07 14:35'
-        message: add warning about nuxeo.loopback.url when changing nuxeo.bind.address
-        version: '41'
-    -
-        author: Thierry Martins
-        date: '2011-05-20 17:35'
-        message: ''
-        version: '40'
-    -
-        author: Stéphane Lacoin
-        date: '2011-05-06 16:44'
-        message: ''
-        version: '39'
-    -
-        author: Wojciech Sulejman
-        date: '2011-04-08 21:32'
-        message: ''
-        version: '38'
-    -
-        author: Wojciech Sulejman
-        date: '2011-04-08 21:30'
-        message: ''
-        version: '37'
-    -
-        author: Wojciech Sulejman
-        date: '2011-04-08 21:22'
-        message: ''
-        version: '36'
-    -
-        author: Julien Carsique
-        date: '2011-03-11 17:10'
-        message: ''
-        version: '35'
-    -
-        author: Julien Carsique
-        date: '2011-03-11 17:05'
-        message: ''
-        version: '34'
-    -
-        author: Solen Guitter
-        date: '2011-03-11 16:50'
-        message: add proxy settings
-        version: '33'
-    -
-        author: Julien Carsique
-        date: '2011-03-11 16:38'
-        message: add proxy settings
-        version: '32'
-    -
-        author: Solen Guitter
-        date: '2011-03-11 15:37'
-        message: ''
-        version: '31'
-    -
-        author: Julien Carsique
-        date: '2011-03-11 15:14'
-        message: ''
-        version: '30'
-    -
-        author: Julien Carsique
-        date: '2011-03-11 15:14'
-        message: ''
-        version: '29'
-    -
-        author: Julien Carsique
-        date: '2011-03-11 15:13'
-        message: ''
-        version: '28'
-    -
-        author: Julien Carsique
-        date: '2011-03-11 15:12'
-        message: ''
-        version: '27'
-    -
-        author: Julien Carsique
-        date: '2011-03-10 19:54'
-        message: explain org.nuxeo.ecm.webapp.dashboard.mode
-        version: '26'
-    -
-        author: Solen Guitter
-        date: '2011-03-04 17:17'
-        message: ''
-        version: '25'
-    -
-        author: Julien Carsique
-        date: '2011-02-28 19:22'
-        message: ''
-        version: '24'
-    -
-        author: Julien Carsique
-        date: '2011-02-23 15:25'
-        message: add nuxeo.wizard.done parameter
-        version: '23'
-    -
-        author: Julien Carsique
-        date: '2011-02-23 15:22'
-        message: ''
-        version: '22'
-    -
-        author: Stéphane Lacoin
-        date: '2011-02-22 15:43'
-        message: ''
-        version: '21'
-    -
-        author: Florent Guillaume
-        date: '2011-02-09 14:25'
-        message: added nuxeo.loopback.url
-        version: '20'
-    -
-        author: Laurent Doguin
-        date: '2011-02-04 17:49'
-        message: ''
-        version: '19'
-    -
-        author: Julien Carsique
-        date: '2011-01-18 11:37'
-        message: ''
-        version: '18'
-    -
-        author: Julien Carsique
-        date: '2011-01-17 15:39'
-        message: ''
-        version: '17'
-    -
-        author: Julien Carsique
-        date: '2011-01-17 15:36'
-        message: ''
-        version: '16'
-    -
-        author: Mathieu Guillaume
-        date: '2010-11-27 15:20'
-        message: ''
-        version: '15'
-    -
-        author: Mathieu Guillaume
-        date: '2010-11-08 17:52'
-        message: ''
-        version: '14'
-    -
-        author: Julien Carsique
-        date: '2010-10-28 19:16'
-        message: NXP-5864
-        version: '13'
-    -
-        author: Julien Carsique
-        date: '2010-10-20 16:47'
-        message: ''
-        version: '12'
-    -
-        author: Julien Carsique
-        date: '2010-10-13 11:40'
-        message: ''
-        version: '11'
-    -
-        author: Julien Carsique
-        date: '2010-09-22 14:47'
-        message: ''
-        version: '10'
-    -
-        author: Julien Carsique
-        date: '2010-09-10 12:32'
-        message: ''
-        version: '9'
-    -
-        author: Julien Carsique
-        date: '2010-09-10 12:30'
-        message: ''
-        version: '8'
-    -
-        author: Julien Carsique
-        date: '2010-09-10 12:30'
-        message: ''
-        version: '7'
-    -
-        author: Julien Carsique
-        date: '2010-09-08 19:31'
-        message: add cluster template options
-        version: '6'
-    -
-        author: Mathieu Guillaume
-        date: '2010-09-01 15:04'
-        message: ''
-        version: '5'
-    -
-        author: Laurent Doguin
-        date: '2010-08-24 19:18'
-        message: Add jod parameters
-        version: '4'
-    -
-        author: Mathieu Guillaume
-        date: '2010-08-02 17:56'
-        message: ''
-        version: '3'
-    -
-        author: Julien Carsique
-        date: '2010-08-02 17:18'
-        message: ''
-        version: '2'
-    -
-        author: Julien Carsique
-        date: '2010-08-02 17:15'
-        message: ''
-        version: '1'
-
+  LTS 2015: 710/admindoc/configuration-parameters-index-nuxeoconf
+  '6.0': 60/admindoc/configuration-parameters-index-nuxeoconf
+  '5.8': 58/admindoc/configuration-parameters-index-nuxeoconf
 ---
+
 The Nuxeo Platform reads configuration properties that you can set either:
 
-*   In a nuxeo.conf file
-*   By contributing to the [Configuration Service](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.runtime.ConfigurationService--configuration#contribute)
-*   From the Setup tab in the Admin Center (if Nuxeo JSF UI is installed)
+- In a nuxeo.conf file
+- By contributing to the [Configuration Service](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.runtime.ConfigurationService--configuration#contribute)
+- From the Setup tab in the Admin Center (if Nuxeo JSF UI is installed)
 
 ## nuxeo.conf File {{> anchor 'conf-manual-edition'}}
 
@@ -1100,8 +64,8 @@ Administrators can also change the `nuxeo.conf` configuration parameters from th
 
 1.  Log in with an administrator account.
     Default administrator credentials are:
-    *   login: `Administrator`
-    *   password: `Administrator`
+    - login: `Administrator`
+    - password: `Administrator`
 2.  Click on the **Admin** tab in the page header.
 3.  Click on the **Setup** tab, edit the configuration you want to change and click on **Save**.
     ![]({{file name='AdminCenter_SetupTab.png' page='admin-tab-overview'}} ?w=650,border=true)
@@ -1111,255 +75,263 @@ Administrators can also change the `nuxeo.conf` configuration parameters from th
 
 You can also take a look at the following pages for recommendations and examples:
 
-*   [Setup Best Practices]({{page page='setup-best-practices'}})
+- [Setup Best Practices]({{page page='setup-best-practices'}})
 
 {{/callout}}
 
 ## Configuration Parameters Index
 
-The table below lists the properties that you can set in nuxeo.conf. Properties that can be contributed to the Configuration service are available [from the Nuxeo Platform Explorer](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.runtime.ConfigurationService--configuration#contribute).
+The properties that can be set in nuxeo.conf are below. Properties that can be contributed to the Configuration service are available [from the Nuxeo Platform Explorer](http://explorer.nuxeo.com/nuxeo/site/distribution/latest/viewExtensionPoint/org.nuxeo.runtime.ConfigurationService--configuration#contribute).
 
-{{! table-filter removed }}
-<div class="table-scroll">
-<table class="hover">
-<tbody>
-<tr>
-<th width="250" colspan="1">Parameter</th>
-<th colspan="1">Description</th>
-<th width="250" colspan="1">Default value ("|" separates possible values)</th>
-<th width="150" colspan="1">Since</th>
-</tr>
-<tr>
-<td colspan="1">`JAVA_HOME`</td>
-<td colspan="1">Path to Java home directory.</td>
-<td colspan="1">None.<br/>
-If undefined nuxeoctl script will try to discover it.</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`JAVA_OPTS`</td>
-<td colspan="1">Optional values passed to the JVM.<br/>
+#### `JAVA_HOME`
+
+Path to Java home directory.
+
+_Default value:_ None.<br/>
+If undefined nuxeoctl script will try to discover it.
+
+#### `JAVA_OPTS`
+
+Optional values passed to the JVM.<br/>
 Nuxeo requires at least 1024 Mo in JVM heap size and 256Mo as maximum permanent size (512 recommended).<br/>
-Decreasing garbage collector frequency avoid having too much CPU usage (Sun Java specific options, recommended by JBoss).</td>
-<td colspan="1">
+Decreasing garbage collector frequency avoid having too much CPU usage (Sun Java specific options, recommended by JBoss).
+
+_Default value:_
 `-Xms512m -Xmx1024m -XX:MaxPermSize=512m`
 `-Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000`
 `-Dfile.encoding=UTF-8`
-</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`launcher.start.max.wait`</td>
-<td colspan="1">In seconds. Maximum time to wait for effective Nuxeo server start before giving up (applies on commands "start" and "restart").</td>
-<td colspan="1">300</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`launcher.stop.max.wait`</td>
-<td colspan="1">In seconds. Maximum time to wait for effective Nuxeo server stop cleanly before using forced stop.</td>
-<td colspan="1">60</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`launcher.override.java.tmpdir`</td>
-<td colspan="1">Possible values: `true` or `false` .<br/>
-If true, will set `java.io.tmpdir = ${nuxeo.tmp.dir}`.</td>
-<td colspan="1">true</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.log.dir`</td>
-<td colspan="1">Log directory (absolute or relative to `NUXEO_HOME`).<br/>
-Linux recommended path: `/var/log/nuxeo/...`</td>
-<td colspan="1">log</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.pid.dir`</td>
-<td colspan="1">Directory where to store Nuxeo PID file.</td>
-<td colspan="1">bin</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.data.dir`</td>
-<td colspan="1">Data directory (absolute or relative to NUXEO_HOME). It involves all data not being stored in database.<br/>
-Linux recommended path: `/var/lib/nuxeo/...`</td>
-<td colspan="1">data</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.tmp.dir`</td>
-<td colspan="1">Location of the temporary files.</td>
-<td colspan="1">`server/default/tmp` (JBoss)<br/>
-`tmp` (Tomcat)<br/>
-`tmp` (Jetty)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.mp.dir`</td>
-<td colspan="1">Since Nuxeo 5.9.4\. Nuxeo Packages directory.</td>
-<td colspan="1">`packages`</td>
-<td colspan="1">Since Nuxeo 5.9.4</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.force.generation`</td>
-<td colspan="1">If "`true`", will force generation of configuration files; otherwise they are only generated when not existing.<br/>
-If "`once`", will force one time and switch to false after successful generation.<br/>
-If "`false`", configuration changes are ignored.</td>
-<td colspan="1">`true` | `once`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.templates`</td>
-<td colspan="1">Comma separated list of templates to include.<br/>
-Templates paths are absolute or relative to `$NUXEO_HOME/templates/`.<br/>
-Available templates: postgresql, mysql, mssql, oracle, custom, ...</td>
-<td colspan="1">default</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.bind.address`</td>
-<td colspan="1">Server binding address. "0.0.0.0" means "all available network interfaces".<br/>
-WARNING: When changing `nuxeo.bind.address`, you must accordingly change `nuxeo.loopback.url`.</td>
-<td colspan="1">0.0.0.0</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.http.port`</td>
-<td colspan="1">Server HTTP listen port.</td>
-<td colspan="1">8080</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.http.connectionUploadTimeout`</td>
-<td colspan="1">Since 10.3. Configure the Tomcat `connectionUploadTimeout` to specify the timeout, in milliseconds, to use while a data upload is in progress.</td>
-<td colspan="1">60000</td>
-<td colspan="1">Since 10.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.ajp.port`</td>
-<td colspan="1">Server AJP listen port.<br/>
-This is not available on Jetty.</td>
-<td colspan="1">8009</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.jvmRoute`</td>
-<td colspan="1">Server AJP route for load-balancing</td>
-<td colspan="1">nuxeo</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.tomcat_admin.host`</td>
-<td colspan="1">Since Nuxeo 7.3\. Tomcat server's "admin" host.<br/>
-This is the address on which the server waits for a shutdown command.</td>
-<td colspan="1">localhost</td>
-<td colspan="1">Since Nuxeo 7.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.tomcat-admin.port`</td>
-<td colspan="1">Deprecated since Nuxeo 5.6 and replaced by `nuxeo.server.tomcat_admin.port`. Tomcat server's "admin" port.<br/>
-This is only useful if you have another Tomcat server running and want to avoid port conflicts.</td>
-<td colspan="1">8005</td>
-<td colspan="1">Deprecated since Nuxeo 5.6</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.tomcat_admin.port`</td>
-<td colspan="1">Since Nuxeo 5.6\. Tomcat server's "admin" port.<br/>
-Replaces `nuxeo.server.tomcat-admin.port`. This is only useful if you have another Tomcat server running and want to avoid port conflicts.</td>
-<td colspan="1">8005</td>
-<td colspan="1">Since Nuxeo 5.6</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.tomcat_error.show_report`</td>
-<td colspan="1">Tomcat report displayed or not on Tomcat error page.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.tomcat_error.show_server_info`</td>
-<td colspan="1">Tomcat version info (as Tomcat server version) displayed or not on Tomcat error page.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.https.port`</td>
-<td colspan="1">Server HTTPS listen port.<br/>
-This is only useful if you have modified the application server to use HTTPS.</td>
-<td colspan="1">8443</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.emptySessionPath`</td>
-<td colspan="1">(Tomcat only) Since Nuxeo 5.5, until 5.7.1\. If set to true, all paths for session cookies will be set to `/`.<br/>
-May be useful to enable authentication on proxyfied WebEngine applications (see [HTTP and HTTPS Reverse-Proxy Configuration]({{page page='http-and-https-reverse-proxy-configuration'}})).<br/>
-Removed since Nuxeo 5.7.2 (see [http://tomcat.apache.org/migration-7.html#Session_cookie_configuration](http://tomcat.apache.org/migration-7.html#Session_cookie_configuration)).</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 5.5, until Nuxeo 5.7.1</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.server.signature`</td>
-<td colspan="1">(Tomcat only) Since Nuxeo 6.0\. If set, this will replace the default value of the "Server:" HTTP response header.</td>
-<td colspan="1">None</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.instance.name`</td>
-<td colspan="1">Server name.</td>
-<td colspan="1">Nuxeo 5.9.3-SNAPSHOT</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.instance.description`</td>
-<td colspan="1">Server description.</td>
-<td colspan="1">Nuxeo</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.product.name`</td>
-<td colspan="1">Product name, displayed in the page title on your browser.</td>
-<td colspan="1">Nuxeo Platform</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.product.version`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">5.9.3-SNAPSHOT</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">{{> anchor 'orgnuxeodev'}} `org.nuxeo.dev`</td>
-<td colspan="1">Since Nuxeo 5.6, this property uses the "dev" mode when running the Nuxeo application. This parameter should not be set to `true` on a production server, as it disables some caches, and enables hot redeploy of some JARs (Studio JARs for instance). For more information about the dev mode, see [How to do incremental deployment (hot reload) in the JSF-Seam layer]({{page space='corg' page='supporting-hot-reload'}}).
 
-Before 5.6, setting this property to true stopped the runtime when an error occured at deployment. This behaviour has been removed from the dev mode and is now controlled by the property `org.nuxeo.runtime.strict`.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 5.6</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.prod`</td>
-<td colspan="1">Since Nuxeo 5.8, setting this property to "true" will display a quite visible warning message in the Admin tab, stating that this is a production instance. This is useful for administrators who are sometimes confusing their Nuxeo production server with their test server (not to rat anyone out).</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-<td colspan="1">false</td>
-</tr>
-<tr>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.rest.stack.enable'}}`org.nuxeo.rest.stack.enable`
+#### `launcher.start.max.wait`
+
+In seconds. Maximum time to wait for effective Nuxeo server start before giving up (applies on commands "start" and "restart").
+
+_Default value:_ 300
+
+#### `launcher.stop.max.wait`
+
+In seconds. Maximum time to wait for effective Nuxeo server stop cleanly before using forced stop.
+
+_Default value:_ 60
+
+#### `launcher.override.java.tmpdir`
+
+Possible values: `true` or `false` .<br/>
+If true, will set `java.io.tmpdir = ${nuxeo.tmp.dir}`.
+
+_Default value:_ true
+
+#### `nuxeo.log.dir`
+
+Log directory (absolute or relative to `NUXEO_HOME`).<br/>
+Linux recommended path: `/var/log/nuxeo/...`
+
+_Default value:_ log
+
+#### `nuxeo.pid.dir`
+
+Directory where to store Nuxeo PID file.
+
+_Default value:_ bin
+
+#### `nuxeo.data.dir`
+
+Data directory (absolute or relative to NUXEO_HOME). It involves all data not being stored in database.<br/>
+Linux recommended path: `/var/lib/nuxeo/...`
+
+_Default value:_ data
+
+#### `nuxeo.tmp.dir`
+
+Location of the temporary files.
+
+_Default value:_ `server/default/tmp` (JBoss)<br/>
+`tmp` (Tomcat)<br/>
+`tmp` (Jetty)
+
+#### `nuxeo.mp.dir`
+
+**Since Nuxeo 5.9.4**
+
+Since Nuxeo 5.9.4\. Nuxeo Packages directory.
+
+_Default value:_ `packages`
+
+#### `nuxeo.force.generation`
+
+If "`true`", will force generation of configuration files; otherwise they are only generated when not existing.<br/>
+If "`once`", will force one time and switch to false after successful generation.<br/>
+If "`false`", configuration changes are ignored.
+
+_Default value:_ `true` | `once`
+
+#### `nuxeo.templates`
+
+Comma separated list of templates to include.<br/>
+Templates paths are absolute or relative to `$NUXEO_HOME/templates/`.<br/>
+Available templates: postgresql, mysql, mssql, oracle, custom, ...
+
+_Default value:_ default
+
+#### `nuxeo.bind.address`
+
+Server binding address. "0.0.0.0" means "all available network interfaces".<br/>
+WARNING: When changing `nuxeo.bind.address`, you must accordingly change `nuxeo.loopback.url`.
+
+_Default value:_ 0.0.0.0
+
+#### `nuxeo.server.http.port`
+
+Server HTTP listen port.
+
+_Default value:_ 8080
+
+#### `nuxeo.server.http.connectionUploadTimeout`
+
+**Since 10.3**
+
+Since 10.3. Configure the Tomcat `connectionUploadTimeout` to specify the timeout, in milliseconds, to use while a data upload is in progress.
+
+_Default value:_ 60000
+
+#### `nuxeo.server.ajp.port`
+
+Server AJP listen port.<br/>
+This is not available on Jetty.
+
+_Default value:_ 8009
+
+#### `nuxeo.server.jvmRoute`
+
+Server AJP route for load-balancing
+
+_Default value:_ nuxeo
+
+#### `nuxeo.server.tomcat_admin.host`
+
+**Since Nuxeo 7.3**
+
+Since Nuxeo 7.3\. Tomcat server's "admin" host.<br/>
+This is the address on which the server waits for a shutdown command.
+
+_Default value:_ localhost
+
+#### `nuxeo.server.tomcat-admin.port`
+
+**Deprecated since Nuxeo 5.6**
+
+Deprecated since Nuxeo 5.6 and replaced by `nuxeo.server.tomcat_admin.port`. Tomcat server's "admin" port.<br/>
+This is only useful if you have another Tomcat server running and want to avoid port conflicts.
+
+_Default value:_ 8005
+
+#### `nuxeo.server.tomcat_admin.port`
+
+**Since Nuxeo 5.6**
+
+Since Nuxeo 5.6\. Tomcat server's "admin" port.<br/>
+Replaces `nuxeo.server.tomcat-admin.port`. This is only useful if you have another Tomcat server running and want to avoid port conflicts.
+
+_Default value:_ 8005
+
+#### `nuxeo.server.tomcat_error.show_report`
+
+**Since Nuxeo 9.3**
+
+Tomcat report displayed or not on Tomcat error page.
+
+_Default value:_ false
+
+#### `nuxeo.server.tomcat_error.show_server_info`
+
+**Since Nuxeo 9.3**
+
+Tomcat version info (as Tomcat server version) displayed or not on Tomcat error page.
+
+_Default value:_ false
+
+#### `nuxeo.server.https.port`
+
+Server HTTPS listen port.<br/>
+This is only useful if you have modified the application server to use HTTPS.
+
+_Default value:_ 8443
+
+#### `nuxeo.server.emptySessionPath`
+
+**Since Nuxeo 5.5, until Nuxeo 5.7.1**
+
+(Tomcat only) Since Nuxeo 5.5, until 5.7.1\. If set to true, all paths for session cookies will be set to `/`.<br/>
+May be useful to enable authentication on proxyfied WebEngine applications (see [HTTP and HTTPS Reverse-Proxy Configuration]({{page page='http-and-https-reverse-proxy-configuration'}})).<br/>
+Removed since Nuxeo 5.7.2 (see [http://tomcat.apache.org/migration-7.html#Session_cookie_configuration](http://tomcat.apache.org/migration-7.html#Session_cookie_configuration)).
+
+_Default value:_ false
+
+#### `nuxeo.server.signature`
+
+(Tomcat only) Since Nuxeo 6.0\. If set, this will replace the default value of the "Server:" HTTP response header.
+
+_Default value:_ None
+
+#### `org.nuxeo.ecm.instance.name`
+
+Server name.
+
+_Default value:_ Nuxeo 5.9.3-SNAPSHOT
+
+#### `org.nuxeo.ecm.instance.description`
+
+Server description.
+
+_Default value:_ Nuxeo
+
+#### `org.nuxeo.ecm.product.name`
+
+Product name, displayed in the page title on your browser.
+
+_Default value:_ Nuxeo Platform
+
+#### `org.nuxeo.ecm.product.version`
+
+_Default value:_ 5.9.3-SNAPSHOT
+
+### {{> anchor 'orgnuxeodev'}} `org.nuxeo.dev`
+
+**Since Nuxeo 5.6**
+
+Since Nuxeo 5.6, this property uses the "dev" mode when running the Nuxeo application. This parameter should not be set to `true` on a production server, as it disables some caches, and enables hot redeploy of some JARs (Studio JARs for instance). For more information about the dev mode, see [How to do incremental deployment (hot reload) in the JSF-Seam layer]({{page space='corg' page='supporting-hot-reload'}}).
+
+Before 5.6, setting this property to true stopped the runtime when an error occured at deployment. This behaviour has been removed from the dev mode and is now controlled by the property `org.nuxeo.runtime.strict`.
+
+_Default value:_ false
+
+#### `org.nuxeo.prod`
+
+**Since Nuxeo 5.8**
+
+Since Nuxeo 5.8, setting this property to "true" will display a quite visible warning message in the Admin tab, stating that this is a production instance. This is useful for administrators who are sometimes confusing their Nuxeo production server with their test server (not to rat anyone out).
+
+_Default value:_ false
+
+### {{! multiexcerpt name='org.nuxeo.rest.stack.enable'}}`org.nuxeo.rest.stack.enable`
+
 {{! /multiexcerpt}}
-</td>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.rest.stack.enable-description'}}
+
+**Since Nuxeo 6.0**
+
+{{! multiexcerpt name='org.nuxeo.rest.stack.enable-description'}}
 Since Nuxeo 6.0, you can enable this mode if you'd like to display exception stacktraces in JSON response when error occurs after REST calls.
 
 See [Web Exceptions documentation]({{page page='error-handling'}}) to get modes description and examples.
-{{! /multiexcerpt}}</td>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.rest.stack.enable-default'}}
+{{! /multiexcerpt}}
+
+_Default value:_ {{! multiexcerpt name='org.nuxeo.rest.stack.enable-default'}}
 false
-{{! /multiexcerpt}}</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.automation.trace'}}
+{{! /multiexcerpt}}
+
+### {{! multiexcerpt name='org.nuxeo.automation.trace'}}
+
 `org.nuxeo.automation.trace`
-{{! /multiexcerpt}}</td>
-<td colspan="1">
+{{! /multiexcerpt}}
 
 Enable this mode if you'd like to display automation traces during runtime:<br/>
 
@@ -1369,1206 +341,1357 @@ Enable this mode if you'd like to display automation traces during runtime:<br/>
 - The automation trace mode is disabled by default (not suitable for production).<br/>
 - It can be activated through JMX via `org.nuxeo:TracerFactory` MBean during runtime.
 
-{{! /multiexcerpt}}</td>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.automation.trace-default'}}
+{{! /multiexcerpt}}
+
+_Default value:_ {{! multiexcerpt name='org.nuxeo.automation.trace-default'}}
 false
 {{! /multiexcerpt}}
-</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.automation.trace.printable'}}
-`org.nuxeo.automation.trace.printable`
-{{! /multiexcerpt}}</td>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.automation.trace.printable-description'}}
-By default, all automation executions are 'printable' (appear in logs) when automation trace mode is on.<br/>
-- You can filter chain and/or operation execution trace printing by setting this property to chain name and/or operation separated by comma.<br/>
-- Comment this property to get all automation chains/operations back in printing (by default set to * (star))
 
-{{! /multiexcerpt}}</td>
-<td colspan="1">{{! multiexcerpt name='org.nuxeo.automation.trace.printable-default'}}
-*
-{{! /multiexcerpt}}</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`templateName.target`</td>
-<td colspan="1">Directory where *templateName* files will be deployed.</td>
-<td colspan="1">`server/default/deploy/nuxeo.ear`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mailservice.user`</td>
-<td colspan="1">(JBoss only) User for e-mail authentication.</td>
-<td colspan="1">nobody</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mailservice.password`</td>
-<td colspan="1">(JBoss only) Password for e-mail authentication.</td>
-<td colspan="1">password</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.store.protocol`<br/>
-`mail.transport.protocol`</td>
-<td colspan="1">Server protocol parameters for e-mailing.</td>
-<td colspan="1">pop3<br/>
-smtp</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.user`</td>
-<td colspan="1">User who will receive e-mail (unused in Nuxeo).</td>
-<td colspan="1">nobody</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.store.host`</td>
-<td colspan="1">e-Mail server.</td>
-<td colspan="1">localhost</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.store.user`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">anonymous</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.store.password`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">password</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.debug`</td>
-<td colspan="1">Enable debugging output from the JavaMail classes.</td>
-<td colspan="1">false</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.notification.eMailSubjectPrefix`</td>
-<td colspan="1">Subject prefix in Nuxeo notification e-mails.</td>
-<td colspan="1">[Nuxeo]</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.notification.eMailSigner`</td>
-<td colspan="1">Signer of the sent e-mail.</td>
-<td colspan="1">The Nuxeo team</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.transport.host`</td>
-<td colspan="1">SMTP gateway server.</td>
-<td colspan="1">localhost</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr><td colspan="1">`mail.transport.port`</td>
-<td colspan="1">e-Mail server port.</td>
-<td colspan="1">25 (without authentication)<br/>
+### {{! multiexcerpt name='org.nuxeo.automation.trace.printable'}}
+
+`org.nuxeo.automation.trace.printable`
+{{! /multiexcerpt}}
+
+{{! multiexcerpt name='org.nuxeo.automation.trace.printable-description'}}
+By default, all automation executions are 'printable' (appear in logs) when automation trace mode is on.<br/>
+
+- You can filter chain and/or operation execution trace printing by setting this property to chain name and/or operation separated by comma.<br/>
+- Comment this property to get all automation chains/operations back in printing (by default set to \* (star))
+
+{{! /multiexcerpt}}
+
+_Default value:_ {{! multiexcerpt name='org.nuxeo.automation.trace.printable-default'}} \*
+{{! /multiexcerpt}}
+
+#### `templateName.target`
+
+Directory where _templateName_ files will be deployed.
+
+_Default value:_ `server/default/deploy/nuxeo.ear`
+
+#### `mailservice.user`
+
+(JBoss only) User for e-mail authentication.
+
+_Default value:_ nobody
+
+#### `mailservice.password`
+
+(JBoss only) Password for e-mail authentication.
+
+_Default value:_ password
+
+#### `mail.store.protocol`<br/>
+
+`mail.transport.protocol`
+
+Server protocol parameters for e-mailing.
+
+_Default value:_ pop3<br/>
+smtp
+
+#### `mail.user`
+
+User who will receive e-mail (unused in Nuxeo).
+
+_Default value:_ nobody
+
+#### `mail.store.host`
+
+e-Mail server.
+
+_Default value:_ localhost
+
+#### `mail.store.user`
+
+_Default value:_ anonymous
+
+#### `mail.store.password`
+
+_Default value:_ password
+
+#### `mail.debug`
+
+Enable debugging output from the JavaMail classes.
+
+_Default value:_ false
+
+#### `nuxeo.notification.eMailSubjectPrefix`
+
+Subject prefix in Nuxeo notification e-mails.
+
+_Default value:_ [Nuxeo]
+
+#### `nuxeo.notification.eMailSigner`
+
+Signer of the sent e-mail.
+
+_Default value:_ The Nuxeo team
+
+#### `mail.transport.host`
+
+SMTP gateway server.
+
+_Default value:_ localhost
+
+#### `mail.transport.port`
+
+e-Mail server port.
+
+_Default value:_ 25 (without authentication)<br/>
 587 (with authentication)<br/>
-465 (SSL)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.transport.usetls`</td>
-<td colspan="1">Use TLS for the SMTP connection.</td>
-<td colspan="1">false</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.transport.auth`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">true</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.transport.user`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">anonymous</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.transport.password`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">password</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`mail.from`</td>
-<td colspan="1">The e-mail address will be sent from.</td>
-<td colspan="1">noreply@nuxeo.com</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.name`</td>
-<td colspan="1">Database name.</td>
-<td colspan="1">nuxeo | NUXEO</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.user`</td>
-<td colspan="1">Database username.</td>
-<td colspan="1">sa | nuxeo</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr><td colspan="1">`nuxeo.db.password`</td>
-<td colspan="1">Database password.</td>
-<td colspan="1">(empty value) | password</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.host`</td>
-<td colspan="1">Database host URL.</td>
-<td colspan="1">localhost</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.port`</td>
-<td colspan="1">Database host port.</td>
-<td colspan="1">3700 (DB2)<br/>
+465 (SSL)
+
+#### `mail.transport.usetls`
+
+Use TLS for the SMTP connection.
+
+_Default value:_ false
+
+#### `mail.transport.auth`
+
+_Default value:_ true
+
+#### `mail.transport.user`
+
+_Default value:_ anonymous
+
+#### `mail.transport.password`
+
+_Default value:_ password
+
+#### `mail.from`
+
+The e-mail address will be sent from.
+
+_Default value:_ noreply@nuxeo.com
+
+#### `nuxeo.db.name`
+
+Database name.
+
+_Default value:_ nuxeo | NUXEO
+
+#### `nuxeo.db.user`
+
+Database username.
+
+_Default value:_ sa | nuxeo
+
+#### `nuxeo.db.password`
+
+Database password.
+
+_Default value:_ (empty value) | password
+
+#### `nuxeo.db.host`
+
+Database host URL.
+
+_Default value:_ localhost
+
+#### `nuxeo.db.port`
+
+Database host port.
+
+_Default value:_ 3700 (DB2)<br/>
 5432 (PostgreSQL)<br/>
 3306 (MySQL)<br/>
 1521 (Oracle)<br/>
-1433 (MSSQL)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.jdbc.url`</td>
-<td colspan="1">Database JDBC connection URL for Nuxeo datasources, for instance `jdbc:postgresql://${nuxeo.db.host}:${nuxeo.db.port}/${nuxeo.db.name`}.</td>
-<td colspan="1">(database-dependent)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.validationQuery`</td>
-<td colspan="1">Database validation query, a `SELECT` statement used to check connections before using them, usually `SELECT 1`. Using this has a noticeable speed impact but makes connections resilient to network or sever problems.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.min-pool-size`</td>
-<td colspan="1">Database minimum pool size for Nuxeo datasources.</td>
-<td colspan="1">5</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.max-pool-size`</td>
-<td colspan="1">Database maximum pool size for Nuxeo datasources.</td>
-<td colspan="1">20 (JBoss)<br/>
-100 (Tomcat)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.idle-timeout-minutes`</td>
-<td colspan="1">Since Nuxeo 6.0\. Database timeout after which connections not in use are removed from the pool.</td>
-<td colspan="1">5</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.xaMode`</td>
-<td colspan="1">Enable XA mode (required if multiple datasources configured)</td>
-<td colspan="1">false</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.min-pool-size`</td>
-<td colspan="1">Database minimum pool size for Nuxeo repository (VCS).</td>
-<td colspan="1">0</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.max-pool-size`</td>
-<td colspan="1">Database maximum pool size for Nuxeo repository (VCS).</td>
-<td colspan="1">20</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.blocking-timeout-millis`</td>
-<td colspan="1">Since Nuxeo 5.8\. Database maximum wait time to get a connection from the pool when all connections are in use, for Nuxeo repository (VCS).</td>
-<td colspan="1">100</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.idle-timeout-minutes`</td>
-<td colspan="1">Since Nuxeo 5.8\. Database timeout after which connections not in use are removed from the pool, for Nuxeo repository (VCS).</td>
-<td colspan="1">10</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.fulltext.disabled`</td>
-<td colspan="1">Since Nuxeo 5.8\. Whether full text indexing and querying should be completely disabled in the repository. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.fulltext.search.disabled`</td>
-<td colspan="1">Since Nuxeo 6.0\. Full text querying from VCS (database backend) is disabled, full text extraction is done. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.fulltext.analyzer.language`</td>
-<td colspan="1">Since Nuxeo 7.3\. Full text analyzer language. Only applies to&nbsp;`postgresql` and `mssql` database types.</td>
-<td colspan="1">english</td>
-<td colspan="1">Since Nuxeo 7.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.noddl`</td>
-<td colspan="1">Since Nuxeo 5.8\. Where DDL generation should be disabled in the repository. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.ddlmode`</td>
-<td colspan="1">Since Nuxeo 7.10-HF01 and Nuxeo 8.1\. What kind of DDL generation is done. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.</td>
-<td colspan="1">execute</td>
-<td colspan="1">Since Nuxeo 7.10-HF01 and Nuxeo 8.1</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.idtype`</td>
-<td colspan="1">Since Nuxeo 5.8\. The type of `id` column. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.</td>
-<td colspan="1">varchar</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.copy.findFreeName.disabled`</td>
-<td colspan="1">Since Nuxeo 7.3\. Set to true to disable free-name detection and let the database raise a constraint error in case of collisions **if the constraints have been added by hand**.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 7.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.url`</td>
-<td colspan="1">Application URL (without final slash), should be the public URL of your server (i.e.: [http://www.yourdomain.com/](http://www.yourdomain.com/)....)<br />
-It is also used for emails sent out and to detect images in HTML documents when converting to PDF.</td>
-<td colspan="1">http://localhost:8080/nuxeo</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.loopback.url`</td>
-<td colspan="1">Nuxeo URL, for connections from Nuxeo to itself (theme banks default). The port should be the same as `nuxeo.server.http.port.`<br/>
-If not explicitly configured, the loop back URL is generated from `nuxeo.bind.address`, `nuxeo.server.http.port` and `org.nuxeo.ecm.contextPath` values.</td>
-<td colspan="1">http://localhost:8080/nuxeo</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.contextPath`</td>
-<td colspan="1">Application context path.<br/>
-Note: Changing this parameter is not enough. See [HOWTO: Change Context Path]({{page page='setup-best-practices'}})</td>
-<td colspan="1">/nuxeo</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.platform.transform.ooo.host.name`</td>
-<td colspan="1">DEPRECATED.</td>
-<td colspan="1">127.0.0.1</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.platform.transform.ooo.host.port`</td>
-<td colspan="1">DEPRECATED.</td>
-<td colspan="1">8100</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.platform.transform.ooo.version`</td>
-<td colspan="1">DEPRECATED.</td>
-<td colspan="1">2.2.1</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.platform.transform.ooo.enableDaemon`</td>
-<td colspan="1">DEPRECATED.</td>
-<td colspan="1">true</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`repository.clustering.enabled`</td>
-<td colspan="1">Activate clustering mode.</td>
-<td colspan="1">false</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`repository.clustering.id`</td>
-<td colspan="1">Since Nuxeo 7.3\. The cluster node id for this Nuxeo instance. The id must be an integer for all databases, unless you are using Oracle which accepts a string (See [NXP-17180](https://jira.nuxeo.com/browse/NXP-17180)).</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since Nuxeo 7.3</td>
-</tr>
-<tr>
-<td colspan="1">`repository.clustering.delay`</td>
-<td colspan="1">When clustering is activated, defines the delay during which invalidations don't need to be processed (expressed in milliseconds).</td>
-<td colspan="1">1000</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`repository.clustering.invalidation`</td>
-<td colspan="1">Allows the configuration of VCS cluster invalidations. The value `default` uses VCS. Since Nuxeo 8.1 you can use `redis` to specify Redis-based invalidations.</td>
-<td colspan="1">default</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`repository.binary.store`</td>
-<td colspan="1">Defines the folder where binaries are stored. Useful when using clustering or to change the location of binaries to another location.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.core.binarymanager`</td>
-<td colspan="1">Custom class for the Binary Manager, to replace the default file-base storage.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.core.binarymanager_key`</td>
-<td colspan="1">Since Nuxeo 6.0\. Key configuration for the binary manager, if applicable.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.templates.parsing.extensions`</td>
-<td colspan="1">Deprecated since Nuxeo 5.6\. Files extensions being parsed for parameters replacement when copying templates.</td>
-<td colspan="1">xml,properties</td>
-<td colspan="1">Deprecated since Nuxeo 5.6</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.plaintext_parsing_extensions`</td>
-<td colspan="1">Since Nuxeo 5.6\. Files extensions being parsed for parameters replacement when copying templates.</td>
-<td colspan="1">xml,properties</td>
-<td colspan="1">Since Nuxeo 5.6</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.jboss.configuration`</td>
-<td colspan="1">JBoss configuration to use (`default`, `minimal`, `all`, ...)<br/>
-Pay attention to the fact that this won't apply to templates defining their own `_template_.target` value (for instance, "default" template sets `default.target=server/default/deploy` without being aware of `org.nuxeo.ecm.jboss.configuration` value).</td>
-<td colspan="1">default</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`zip.entry.encoding`</td>
-<td colspan="1">Choose how to encode filename when exporting documents to zip in the worklist.<br/>
-Since Nuxeo 7.1, the ZIP entries names are encoded in UTF8 by default. If you want to get the old behavior back (having entry name encoded in ascii), use `zip.entry.encoding=ascii`.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Modified since Nuxeo 7.1</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.platform.liveedit.autoversioning`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">none,minor,major</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr><td colspan="1">`nuxeo.wizard.done`</td>
-<td colspan="1">If set to false, will start a setup wizard before starting Nuxeo.</td>
-<td colspan="1">true or false depending on the package</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.http.proxy.host`</td>
-<td colspan="1">HTTP proxy host.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.http.proxy.port`</td>
-<td colspan="1">HTTP proxy port.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.http.proxy.login`</td>
-<td colspan="1">HTTP proxy login.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.http.proxy.password`</td>
-<td colspan="1">HTTP proxy password.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.http.proxy.ntlm.host`</td>
-<td colspan="1">NT Lan Manager (NTLM) Proxy. Host name of the Windows machine running the Nuxeo server.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.http.proxy.ntlm.domain`</td>
-<td colspan="1">NT Lan Manager (NTLM) Proxy. Domain name to authenticate against.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.http.proxy.pac.url`</td>
-<td colspan="1">Since Nuxeo 5.9.3\. Proxy auto-config (PAC) file URL.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since Nuxeo 5.9.3</td>
-</tr>
-<tr>
-<td colspan="1">`facelets.REFRESH_PERIOD`</td>
-<td colspan="1">Indicates to the compiler the number of seconds to wait between subsequent checks for changes in modified JSF facelets in a running application. Useful for facelet debugging.<br/>
+1433 (MSSQL)
+
+#### `nuxeo.db.jdbc.url`
+
+Database JDBC connection URL for Nuxeo datasources, for instance `jdbc:postgresql://${nuxeo.db.host}:${nuxeo.db.port}/${nuxeo.db.name`}.
+
+_Default value:_ (database-dependent)
+
+#### `nuxeo.db.validationQuery`
+
+Database validation query, a `SELECT` statement used to check connections before using them, usually `SELECT 1`. Using this has a noticeable speed impact but makes connections resilient to network or sever problems.
+
+#### `nuxeo.db.min-pool-size`
+
+Database minimum pool size for Nuxeo datasources.
+
+_Default value:_ 5
+
+#### `nuxeo.db.max-pool-size`
+
+Database maximum pool size for Nuxeo datasources.
+
+_Default value:_ 20 (JBoss)<br/>
+100 (Tomcat)
+
+#### `nuxeo.db.idle-timeout-minutes`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. Database timeout after which connections not in use are removed from the pool.
+
+_Default value:_ 5
+
+#### `nuxeo.db.xaMode`
+
+Enable XA mode (required if multiple datasources configured)
+
+_Default value:_ false
+
+#### `nuxeo.vcs.min-pool-size`
+
+Database minimum pool size for Nuxeo repository (VCS).
+
+_Default value:_ 0
+
+#### `nuxeo.vcs.max-pool-size`
+
+Database maximum pool size for Nuxeo repository (VCS).
+
+_Default value:_ 20
+
+#### `nuxeo.vcs.blocking-timeout-millis`
+
+**Since Nuxeo 5.8**
+
+Since Nuxeo 5.8\. Database maximum wait time to get a connection from the pool when all connections are in use, for Nuxeo repository (VCS).
+
+_Default value:_ 100
+
+#### `nuxeo.vcs.idle-timeout-minutes`
+
+**Since Nuxeo 5.8**
+
+Since Nuxeo 5.8\. Database timeout after which connections not in use are removed from the pool, for Nuxeo repository (VCS).
+
+_Default value:_ 10
+
+#### `nuxeo.vcs.fulltext.disabled`
+
+**Since Nuxeo 5.8**
+
+Since Nuxeo 5.8\. Whether full text indexing and querying should be completely disabled in the repository. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
+
+_Default value:_ false
+
+#### `nuxeo.vcs.fulltext.search.disabled`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. Full text querying from VCS (database backend) is disabled, full text extraction is done. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
+
+_Default value:_ false
+
+#### `nuxeo.vcs.fulltext.analyzer.language`
+
+**Since Nuxeo 7.3**
+
+Since Nuxeo 7.3\. Full text analyzer language. Only applies to&nbsp;`postgresql` and `mssql` database types.
+
+_Default value:_ english
+
+#### `nuxeo.vcs.noddl`
+
+**Since Nuxeo 5.8**
+
+Since Nuxeo 5.8\. Where DDL generation should be disabled in the repository. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
+
+_Default value:_ false
+
+#### `nuxeo.vcs.ddlmode`
+
+**Since Nuxeo 7.10-HF01 and Nuxeo 8.1**
+
+Since Nuxeo 7.10-HF01 and Nuxeo 8.1\. What kind of DDL generation is done. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
+
+_Default value:_ execute
+
+#### `nuxeo.vcs.idtype`
+
+**Since Nuxeo 5.8**
+
+Since Nuxeo 5.8\. The type of `id` column. See [VCS]({{page version='' space='nxdoc' page='vcs'}}) for details.
+
+_Default value:_ varchar
+
+#### `nuxeo.vcs.copy.findFreeName.disabled`
+
+**Since Nuxeo 7.3**
+
+Since Nuxeo 7.3\. Set to true to disable free-name detection and let the database raise a constraint error in case of collisions **if the constraints have been added by hand**.
+
+_Default value:_ false
+
+#### `nuxeo.url`
+
+Application URL (without final slash), should be the public URL of your server (i.e.: [http://www.yourdomain.com/](http://www.yourdomain.com/)....)<br />
+It is also used for emails sent out and to detect images in HTML documents when converting to PDF.
+
+_Default value:_ http://localhost:8080/nuxeo
+
+#### `nuxeo.loopback.url`
+
+Nuxeo URL, for connections from Nuxeo to itself (theme banks default). The port should be the same as `nuxeo.server.http.port.`<br/>
+If not explicitly configured, the loop back URL is generated from `nuxeo.bind.address`, `nuxeo.server.http.port` and `org.nuxeo.ecm.contextPath` values.
+
+_Default value:_ http://localhost:8080/nuxeo
+
+#### `org.nuxeo.ecm.contextPath`
+
+Application context path.<br/>
+Note: Changing this parameter is not enough. See [HOWTO: Change Context Path]({{page page='setup-best-practices'}})
+
+_Default value:_ /nuxeo
+
+#### `org.nuxeo.ecm.platform.transform.ooo.host.name`
+
+DEPRECATED.
+
+_Default value:_ 127.0.0.1
+
+#### `org.nuxeo.ecm.platform.transform.ooo.host.port`
+
+DEPRECATED.
+
+_Default value:_ 8100
+
+#### `org.nuxeo.ecm.platform.transform.ooo.version`
+
+DEPRECATED.
+
+_Default value:_ 2.2.1
+
+#### `org.nuxeo.ecm.platform.transform.ooo.enableDaemon`
+
+DEPRECATED.
+
+_Default value:_ true
+
+#### `repository.clustering.enabled`
+
+Activate clustering mode.
+
+_Default value:_ false
+
+#### `repository.clustering.id`
+
+**Since Nuxeo 7.3**
+
+Since Nuxeo 7.3\. The cluster node id for this Nuxeo instance. The id must be an integer for all databases, unless you are using Oracle which accepts a string (See [NXP-17180](https://jira.nuxeo.com/browse/NXP-17180)).
+
+#### `repository.clustering.delay`
+
+When clustering is activated, defines the delay during which invalidations don't need to be processed (expressed in milliseconds).
+
+_Default value:_ 1000
+
+#### `repository.clustering.invalidation`
+
+Allows the configuration of VCS cluster invalidations. The value `default` uses VCS. Since Nuxeo 8.1 you can use `redis` to specify Redis-based invalidations.
+
+_Default value:_ default
+
+#### `repository.binary.store`
+
+Defines the folder where binaries are stored. Useful when using clustering or to change the location of binaries to another location.
+
+#### `nuxeo.core.binarymanager`
+
+Custom class for the Binary Manager, to replace the default file-base storage.
+
+#### `nuxeo.core.binarymanager_key`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. Key configuration for the binary manager, if applicable.
+
+#### `nuxeo.templates.parsing.extensions`
+
+**Deprecated since Nuxeo 5.6**
+
+Deprecated since Nuxeo 5.6\. Files extensions being parsed for parameters replacement when copying templates.
+
+_Default value:_ xml,properties
+
+#### `nuxeo.plaintext_parsing_extensions`
+
+**Since Nuxeo 5.6**
+
+Since Nuxeo 5.6\. Files extensions being parsed for parameters replacement when copying templates.
+
+_Default value:_ xml,properties
+
+#### `org.nuxeo.ecm.jboss.configuration`
+
+JBoss configuration to use (`default`, `minimal`, `all`, ...)<br/>
+Pay attention to the fact that this won't apply to templates defining their own `_template_.target` value (for instance, "default" template sets `default.target=server/default/deploy` without being aware of `org.nuxeo.ecm.jboss.configuration` value).
+
+_Default value:_ default
+
+#### `zip.entry.encoding`
+
+**Modified since Nuxeo 7.1**
+
+Choose how to encode filename when exporting documents to zip in the worklist.<br/>
+Since Nuxeo 7.1, the ZIP entries names are encoded in UTF8 by default. If you want to get the old behavior back (having entry name encoded in ascii), use `zip.entry.encoding=ascii`.
+
+#### `org.nuxeo.ecm.platform.liveedit.autoversioning`
+
+_Default value:_ none,minor,major
+
+#### `nuxeo.wizard.done`
+
+If set to false, will start a setup wizard before starting Nuxeo.
+
+_Default value:_ true or false depending on the package
+
+#### `nuxeo.http.proxy.host`
+
+HTTP proxy host.
+
+#### `nuxeo.http.proxy.port`
+
+HTTP proxy port.
+
+#### `nuxeo.http.proxy.login`
+
+HTTP proxy login.
+
+#### `nuxeo.http.proxy.password`
+
+HTTP proxy password.
+
+#### `nuxeo.http.proxy.ntlm.host`
+
+NT Lan Manager (NTLM) Proxy. Host name of the Windows machine running the Nuxeo server.
+
+#### `nuxeo.http.proxy.ntlm.domain`
+
+NT Lan Manager (NTLM) Proxy. Domain name to authenticate against.
+
+#### `nuxeo.http.proxy.pac.url`
+
+**Since Nuxeo 5.9.3**
+
+Since Nuxeo 5.9.3\. Proxy auto-config (PAC) file URL.
+
+#### `facelets.REFRESH_PERIOD`
+
+Indicates to the compiler the number of seconds to wait between subsequent checks for changes in modified JSF facelets in a running application. Useful for facelet debugging.<br/>
 To disable this compiler check use a value of -1 which is a recommended value for production deployments as compiler checks have an impact on application performance.<br/>
-Since Nuxeo 5.6, the parameter [`undefined`](#orgnuxeodev) should be used instead as it forces this parameter to value "2".</td>
-<td colspan="1">-1</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.db.transactiontimeout`</td>
-<td colspan="1">Database transaction timeout in seconds (available for Tomcat server only)</td>
-<td colspan="1">300</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`server.status.key`</td>
-<td colspan="1">Secure key for connecting to server status monitoring servlet. It is randomly generated if not set.<br/>
-It is also used by default&nbsp;for sensitive configuration data encryption, see `server.crypt.secretkey`.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`session.timeout`</td>
-<td colspan="1">Session timeout (see [web.xml session-timeout](http://www.google.com/search?q=web.xml+session-timeout)).</td>
-<td colspan="1">60</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`session.config.tracking.mode.cookie`</td>
-<td colspan="1">Session tracking mode.<br/>
+Since Nuxeo 5.6, the parameter [`undefined`](#orgnuxeodev) should be used instead as it forces this parameter to value "2".
+
+_Default value:_ -1
+
+#### `nuxeo.db.transactiontimeout`
+
+Database transaction timeout in seconds (available for Tomcat server only)
+
+_Default value:_ 300
+
+#### `server.status.key`
+
+Secure key for connecting to server status monitoring servlet. It is randomly generated if not set.<br/>
+It is also used by default&nbsp;for sensitive configuration data encryption, see `server.crypt.secretkey`.
+
+#### `session.timeout`
+
+Session timeout (see [web.xml session-timeout](http://www.google.com/search?q=web.xml+session-timeout)).
+
+_Default value:_ 60
+
+#### `session.config.tracking.mode.cookie`
+
+**Since Nuxeo 10.2**
+
+Session tracking mode.<br/>
 If `true`, prevents Tomcat from appending the `jsessionid` parameter to the URLs, for example a file download URL. Yet, cookies need to be enabled in the browser.<br/>
 Otherwise, the `jsessionid` parameter might be appended to some URLs, for instance when sharing a document permalink to an anonymous user or when clearing the browser's cookies. Yet, cookies don't need to be enabled in the browser.
-</td>
-<td colspan="1">`true`</td>
-<td colspan="1">Since Nuxeo 10.2</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.updatecenter.disabled`</td>
-<td colspan="1">Disables the Update Center feature.</td>
-<td colspan="1">false (unset)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.big.file.size.limit`</td>
-<td colspan="1">Redirects onto the big file download URL if size exceeds limit.</td>
-<td colspan="1">5Mi (unset)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.ecm.platform.ui.web.auth`<br/>
-`.NuxeoAuthenticationFilter.isLoginNotSynchronized`</td>
-<td colspan="1">Disables login synchronization.</td>
-<td colspan="1">false (unset)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.wizard.packages.url`</td>
-<td colspan="1">Defines the base URL used by the Setup Wizard to get the packages.xml file describing the available software packages options.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.wizard.skippedpages`</td>
-<td colspan="1">Comma separated list of pages that should be skipped inside the wizard.</td>
-<td colspan="1">null</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.jsf. numberOfConversationsInSession`</td>
-<td colspan="1">Since Nuxeo 5.7.2, Parameter to control the number of conversation states that are saved in session. Each conversation holds a number of view states that is defined by `nuxeo.jsf.numberOfViewsInSession`</td>
-<td colspan="1">4</td>
-<td colspan="1">Since Nuxeo 5.7.2</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.jsf.numberOfViewsInSession`</td>
-<td colspan="1">Since Nuxeo 5.7.2 (5.6-HF20) Parameter to control the JSF init parameter `com.sun.faces.numberOfViewsInSession`</td>
-<td colspan="1">4</td>
-<td colspan="1">Since Nuxeo 5.7.2</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.jsf.numberOfLogicalViews`</td>
-<td colspan="1">Since Nuxeo 5.7.2 (5.6-HF20) Parameter to control the JSF init parameter `com.sun.faces.numberOfLogicalViews`</td>
-<td colspan="1">4</td>
-<td colspan="1">Since Nuxeo 5.7.2</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.jsf.tmp.dir`</td>
-<td colspan="1">Since Nuxeo 6.0\. Faces Servlet multi-part config: an absolute path to a directory on the file system. The location attribute does  **not** support a path relative to the application context. This location is used to store files temporarily while the parts are processed or when the size of the file exceeds the specified `fileSizeThreshold` setting. The default location is "".</td>
-<td colspan="1">`nuxeo.tmp.dir` (unset)</span></td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.jsf.maxFileSize`</td>
-<td colspan="1">Since Nuxeo 6.0\. Faces Servlet multi-part config: the maximum size allowed for uploaded files, in bytes. The default size is unlimited.</td>
-<td colspan="1">-1 (unlimited) (unset)</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.jsf.maxRequestSize`</td>
-<td colspan="1">Since Nuxeo 6.0\. Faces Servlet multi-part config: the maximum size allowed for a `multipart/form-data` request, in bytes. The default size is unlimited.</td>
-<td colspan="1">-1 (unlimited) (unset)</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.jsf.fileSizeThreshold`</td>
-<td colspan="1">Since Nuxeo 6.0\. Faces Servlet multi-part config: The file size in bytes after which the file will be temporarily stored on disk. The default size is 0 bytes.</td>
-<td colspan="1">0 (unset)</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.vcs.use-nulls-last-on-desc`</td>
-<td colspan="1">Since Nuxeo 5.8\. Ask the database to use "NULLS LAST" when sorting DESC. True by default to get the same result order between different databases.<br/>
-Also turning this option to false enable PostgreSQL and Oracle to use an index on the sorted column which can be huge performance improvement.</td>
-<td colspan="1">true (unset)</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.connect.connector.cache.duration`</td>
-<td colspan="1">Since Nuxeo 5.6\. Nuxeo Packages list cache (in minutes).</td>
-<td colspan="1">60min (5min for Studio packages)</td>
-<td colspan="1">Since Nuxeo 5.6</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.connect.server.reachable`</td>
-<td colspan="1">Since Nuxeo 5.7\. Launcher online/offline mode for connections to Nuxeo Connect.</td>
-<td colspan="1">true</td>
-<td colspan="1">Since Nuxeo 5.7</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.connect.url`</td>
-<td colspan="1">Nuxeo Connect URL.</td>
-<td colspan="1">[https://connect.nuxeo.com/nuxeo/site/](https://connect.nuxeo.com/nuxeo/site/)</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.automation.properties.multiline.escape`</td>
-<td colspan="1">Enable/Disable multi-line strings escaped with a trailing \ when using `Document.Update` or `Workflow.SetWorkflowVariables` Automation operations.</td>
-<td colspan="1">false</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.cmis.joins`</td>
-<td colspan="1">Since Nuxeo 6.0\. When true, CMISQL JOINs are allowed if VCS is used.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.cmis.proxies`</td>
-<td colspan="1">If false, proxies are not visible through CMIS. Cannot be `true` if `org.nuxeo.cmis.joins` is `true`.</td>
-<td colspan="1">true</td>
-<td colspan="1">Since Nuxeo 7.10-HF08 and Nuxeo 8.3</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.cmis.enableComplexProperties`</td>
-<td colspan="1">Since Nuxeo 7.1\. When true, complex properties are exposed as JSON-encoded strings.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 7.1</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.security.allowNegativeACL`</td>
-<td colspan="1">Since Nuxeo 6.0\. When true, enables adding negative ACL (deny permissions) in the UI, otherwise only grant permissions are available.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`audit.elasticsearch.enabled`</td>
-<td colspan="1">Since Nuxeo 7.3\. See [Disabling Elasticsearch for Audit Logs]({{page version='' space='nxdoc' page='elasticsearch-setup'}}#disabling-elasticsearch-for-audit-logs).<br/>
-Defaults to false on server upgrade, true on new install.</td>
-<td colspan="1">false | true</td>
-<td colspan="1">Since Nuxeo 7.3</td>
-</tr>
-<tr>
-<td colspan="1">`audit.elasticsearch.indexName`</td>
-<td colspan="1">Name of the Elasticsearch index for audit logs.</td>
-<td colspan="1">`${elasticsearch.indexName}`-audit</td>
-<td colspan="1">Since Nuxeo 7.10</td>
-</tr>
-<tr>
-<td colspan="1">`seqgen.elasticsearch.indexName`</td>
-<td colspan="1">Name of the Elasticsearch index for the uid sequencer.</td>
-<td colspan="1">`${elasticsearch.indexName}`-uidgen</td>
-<td colspan="1">Since Nuxeo 7.10</td>
-</tr>
-<tr>
-<td colspan="1">`audit.elasticsearch.migration`</td>
-<td colspan="1">Since Nuxeo 7.3\. See [Triggering SQL to Elasticsearch Audit Logs Migration]({{page version='710' space='admindoc' page='elasticsearch-setup'}}#triggering-sql-to-elasticsearch-audit-logs-migration)</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 7.3</td>
-</tr>
-<tr>
-<td colspan="1">`audit.elasticsearch.migration.batchSize`</td>
-<td colspan="1">Since Nuxeo 7.3\. See [Triggering SQL to Elasticsearch Audit Logs Migration]({{page version='710' space='admindoc' page='elasticsearch-setup'}}#triggering-sql-to-elasticsearch-audit-logs-migration)</td>
-<td colspan="1">1000</td>
-<td colspan="1">Since Nuxeo 7.3</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.httpReadOnly.baseUrl`</td>
-<td colspan="1">Required when using a standalone Elasticsearch instance. See [Elasticsearch Passthrough]({{page version='' space='nxdoc' page='elasticsearch-passthrough'}}#requirement)</td>
-<td colspan="1">http://localhost:9200/</td>
-<td colspan="1">Since Nuxeo 7.10</td>
-</tr>
-<tr>
-<td colspan="1">`org.nuxeo.cmis.elasticsearch`</td>
-<td colspan="1">Since Nuxeo 7.2\. To send the CMISQL queries to Elasticsearch, set to true.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 7.2</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.enabled`</td>
-<td colspan="1">Set to true to activate Redis.</td>
-<td colspan="1">false</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.host`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">redishost</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.port`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">6379</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.password`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.database`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">0</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.timeout`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">2000</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.maxTotal`</td>
-<td colspan="1">The maximum size of the Redis connections pool.</td>
-<td colspan="1">16</td>
-<td colspan="1">Since Nuxeo 8.2</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.maxIdle`</td>
-<td colspan="1">The maximum number of Redis idle connections in the pool.</td>
-<td colspan="1">8</td>
-<td colspan="1">Since Nuxeo 8.2</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.redis.prefix`</td>
-<td colspan="1">This allows you to use a single Redis server between several Nuxeo cluster installations by having a different prefix for each cluster. See the page [Redis Configuration]({{page page='redis-configuration'}}) for more details.</td>
-<td colspan="1">nuxeo:</td>
-<td colspan="1">Since Nuxeo 5.8</td>
-</tr>
-<tr>
-<td colspan="1">`server.crypt.secretkey`</td>
-<td colspan="1">Custom secret key used for sensitive configuration data encryption. It takes either a raw value or an URL (e.g. <a class="external-link" rel="nofollow">file:///path/to/secretkey</a> or [http://some.online.file.com](http://some.online.file.com)).</td>
-<td colspan="1">`${server.status.key}`</td>
-<td colspan="1">Since Nuxeo 7.4</td>
-</tr>
-<tr>
-<td colspan="1">`server.crypt.keystore.path`</td>
-<td colspan="1">Path to the keystore to use for sensitive configuration data encryption.</td>
-<td colspan="1">`${javax.net.ssl.keyStore}`</td>
-<td colspan="1">Since Nuxeo 7.4</td>
-</tr>
-<tr>
-<td colspan="1">`server.crypt.keystore.pass`</td>
-<td colspan="1">The password used to protect the integrity of the keystore contents.</td>
-<td colspan="1">`${javax.net.ssl.keyStorePassword:="changeit"}`</td>
-<td colspan="1">Since Nuxeo 7.4</td>
-</tr>
-<tr>
-<td colspan="1">`server.crypt.keyalias`</td>
-<td colspan="1">The alias prefix where to retrieve the secret key from the keystore. It is automatically suffixed with the algorithm ("AES" or "DES").</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since Nuxeo 7.4</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.virtual.host`</td>
-<td colspan="1">This parameter can be used to replace the nuxeo-virtual-host request header (usually when using HTTPS) when it is not possible to set it at the reverse-proxy level.<br/>
+
+_Default value:_ `true`
+
+#### `nuxeo.updatecenter.disabled`
+
+Disables the Update Center feature.
+
+_Default value:_ false (unset)
+
+#### `org.nuxeo.big.file.size.limit`
+
+Redirects onto the big file download URL if size exceeds limit.
+
+_Default value:_ 5Mi (unset)
+
+#### `org.nuxeo.ecm.platform.ui.web.auth`<br/>
+
+`.NuxeoAuthenticationFilter.isLoginNotSynchronized`
+
+Disables login synchronization.
+
+_Default value:_ false (unset)
+
+#### `nuxeo.wizard.packages.url`
+
+Defines the base URL used by the Setup Wizard to get the packages.xml file describing the available software packages options.
+
+#### `nuxeo.wizard.skippedpages`
+
+Comma separated list of pages that should be skipped inside the wizard.
+
+_Default value:_ null
+
+#### `nuxeo.jsf. numberOfConversationsInSession`
+
+**Since Nuxeo 5.7.2**
+
+Since Nuxeo 5.7.2, Parameter to control the number of conversation states that are saved in session. Each conversation holds a number of view states that is defined by `nuxeo.jsf.numberOfViewsInSession`
+
+_Default value:_ 4
+
+#### `nuxeo.jsf.numberOfViewsInSession`
+
+**Since Nuxeo 5.7.2**
+
+Since Nuxeo 5.7.2 (5.6-HF20) Parameter to control the JSF init parameter `com.sun.faces.numberOfViewsInSession`
+
+_Default value:_ 4
+
+#### `nuxeo.jsf.numberOfLogicalViews`
+
+**Since Nuxeo 5.7.2**
+
+Since Nuxeo 5.7.2 (5.6-HF20) Parameter to control the JSF init parameter `com.sun.faces.numberOfLogicalViews`
+
+_Default value:_ 4
+
+#### `nuxeo.jsf.tmp.dir`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. Faces Servlet multi-part config: an absolute path to a directory on the file system. The location attribute does **not** support a path relative to the application context. This location is used to store files temporarily while the parts are processed or when the size of the file exceeds the specified `fileSizeThreshold` setting. The default location is "".
+
+_Default value:_ `nuxeo.tmp.dir` (unset)</span>
+
+#### `nuxeo.jsf.maxFileSize`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. Faces Servlet multi-part config: the maximum size allowed for uploaded files, in bytes. The default size is unlimited.
+
+_Default value:_ -1 (unlimited) (unset)
+
+#### `nuxeo.jsf.maxRequestSize`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. Faces Servlet multi-part config: the maximum size allowed for a `multipart/form-data` request, in bytes. The default size is unlimited.
+
+_Default value:_ -1 (unlimited) (unset)
+
+#### `nuxeo.jsf.fileSizeThreshold`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. Faces Servlet multi-part config: The file size in bytes after which the file will be temporarily stored on disk. The default size is 0 bytes.
+
+_Default value:_ 0 (unset)
+
+#### `nuxeo.vcs.use-nulls-last-on-desc`
+
+**Since Nuxeo 5.8**
+
+Since Nuxeo 5.8\. Ask the database to use "NULLS LAST" when sorting DESC. True by default to get the same result order between different databases.<br/>
+Also turning this option to false enable PostgreSQL and Oracle to use an index on the sorted column which can be huge performance improvement.
+
+_Default value:_ true (unset)
+
+#### `org.nuxeo.connect.connector.cache.duration`
+
+**Since Nuxeo 5.6**
+
+Since Nuxeo 5.6\. Nuxeo Packages list cache (in minutes).
+
+_Default value:_ 60min (5min for Studio packages)
+
+#### `org.nuxeo.connect.server.reachable`
+
+**Since Nuxeo 5.7**
+
+Since Nuxeo 5.7\. Launcher online/offline mode for connections to Nuxeo Connect.
+
+_Default value:_ true
+
+#### `org.nuxeo.connect.url`
+
+Nuxeo Connect URL.
+
+_Default value:_ [https://connect.nuxeo.com/nuxeo/site/](https://connect.nuxeo.com/nuxeo/site/)
+
+#### `nuxeo.automation.properties.multiline.escape`
+
+Enable/Disable multi-line strings escaped with a trailing \ when using `Document.Update` or `Workflow.SetWorkflowVariables` Automation operations.
+
+_Default value:_ false
+
+#### `org.nuxeo.cmis.joins`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. When true, CMISQL JOINs are allowed if VCS is used.
+
+_Default value:_ false
+
+#### `org.nuxeo.cmis.proxies`
+
+**Since Nuxeo 7.10-HF08 and Nuxeo 8.3**
+
+If false, proxies are not visible through CMIS. Cannot be `true` if `org.nuxeo.cmis.joins` is `true`.
+
+_Default value:_ true
+
+#### `org.nuxeo.cmis.enableComplexProperties`
+
+**Since Nuxeo 7.1**
+
+Since Nuxeo 7.1\. When true, complex properties are exposed as JSON-encoded strings.
+
+_Default value:_ false
+
+#### `nuxeo.security.allowNegativeACL`
+
+**Since Nuxeo 6.0**
+
+Since Nuxeo 6.0\. When true, enables adding negative ACL (deny permissions) in the UI, otherwise only grant permissions are available.
+
+_Default value:_ false
+
+#### `audit.elasticsearch.enabled`
+
+**Since Nuxeo 7.3**
+
+Since Nuxeo 7.3\. See [Disabling Elasticsearch for Audit Logs]({{page version='' space='nxdoc' page='elasticsearch-setup'}}#disabling-elasticsearch-for-audit-logs).<br/>
+Defaults to false on server upgrade, true on new install.
+
+_Default value:_ false | true
+
+#### `audit.elasticsearch.indexName`
+
+**Since Nuxeo 7.10**
+
+Name of the Elasticsearch index for audit logs.
+
+_Default value:_ `${elasticsearch.indexName}`-audit
+
+#### `seqgen.elasticsearch.indexName`
+
+**Since Nuxeo 7.10**
+
+Name of the Elasticsearch index for the uid sequencer.
+
+_Default value:_ `${elasticsearch.indexName}`-uidgen
+
+#### `audit.elasticsearch.migration`
+
+**Since Nuxeo 7.3**
+
+Since Nuxeo 7.3\. See [Triggering SQL to Elasticsearch Audit Logs Migration]({{page version='710' space='admindoc' page='elasticsearch-setup'}}#triggering-sql-to-elasticsearch-audit-logs-migration)
+
+_Default value:_ false
+
+#### `audit.elasticsearch.migration.batchSize`
+
+**Since Nuxeo 7.3**
+
+Since Nuxeo 7.3\. See [Triggering SQL to Elasticsearch Audit Logs Migration]({{page version='710' space='admindoc' page='elasticsearch-setup'}}#triggering-sql-to-elasticsearch-audit-logs-migration)
+
+_Default value:_ 1000
+
+#### `elasticsearch.httpReadOnly.baseUrl`
+
+**Since Nuxeo 7.10**
+
+Required when using a standalone Elasticsearch instance. See [Elasticsearch Passthrough]({{page version='' space='nxdoc' page='elasticsearch-passthrough'}}#requirement)
+
+_Default value:_ http://localhost:9200/
+
+#### `org.nuxeo.cmis.elasticsearch`
+
+**Since Nuxeo 7.2**
+
+Since Nuxeo 7.2\. To send the CMISQL queries to Elasticsearch, set to true.
+
+_Default value:_ false
+
+#### `nuxeo.redis.enabled`
+
+**Since Nuxeo 5.8**
+
+Set to true to activate Redis.
+
+_Default value:_ false
+
+#### `nuxeo.redis.host`
+
+**Since Nuxeo 5.8**
+
+_Default value:_ redishost
+
+#### `nuxeo.redis.port`
+
+**Since Nuxeo 5.8**
+
+_Default value:_ 6379
+
+#### `nuxeo.redis.password`
+
+**Since Nuxeo 5.8**
+
+#### `nuxeo.redis.database`
+
+**Since Nuxeo 5.8**
+
+_Default value:_ 0
+
+#### `nuxeo.redis.timeout`
+
+**Since Nuxeo 5.8**
+
+_Default value:_ 2000
+
+#### `nuxeo.redis.maxTotal`
+
+**Since Nuxeo 8.2**
+
+The maximum size of the Redis connections pool.
+
+_Default value:_ 16
+
+#### `nuxeo.redis.maxIdle`
+
+**Since Nuxeo 8.2**
+
+The maximum number of Redis idle connections in the pool.
+
+_Default value:_ 8
+
+#### `nuxeo.redis.prefix`
+
+**Since Nuxeo 5.8**
+
+This allows you to use a single Redis server between several Nuxeo cluster installations by having a different prefix for each cluster. See the page [Redis Configuration]({{page page='redis-configuration'}}) for more details.
+
+_Default value:_ nuxeo:
+
+#### `server.crypt.secretkey`
+
+**Since Nuxeo 7.4**
+
+Custom secret key used for sensitive configuration data encryption. It takes either a raw value or an URL (e.g. <a class="external-link" rel="nofollow">file:///path/to/secretkey</a> or [http://some.online.file.com](http://some.online.file.com)).
+
+_Default value:_ `${server.status.key}`
+
+#### `server.crypt.keystore.path`
+
+**Since Nuxeo 7.4**
+
+Path to the keystore to use for sensitive configuration data encryption.
+
+_Default value:_ `${javax.net.ssl.keyStore}`
+
+#### `server.crypt.keystore.pass`
+
+**Since Nuxeo 7.4**
+
+The password used to protect the integrity of the keystore contents.
+
+_Default value:_ `${javax.net.ssl.keyStorePassword:="changeit"}`
+
+#### `server.crypt.keyalias`
+
+**Since Nuxeo 7.4**
+
+The alias prefix where to retrieve the secret key from the keystore. It is automatically suffixed with the algorithm ("AES" or "DES").
+
+#### `nuxeo.virtual.host`
+
+**Since Nuxeo 7.4**
+
+This parameter can be used to replace the nuxeo-virtual-host request header (usually when using HTTPS) when it is not possible to set it at the reverse-proxy level.<br/>
 The use of the header is still preferred as the parameter forces your Nuxeo instance to be accessible from one URL only.<br/>
-Example: https://my.nuxeo.com/</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since Nuxeo 7.4</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.enabled`</td>
-<td colspan="1">Switch to enable/disable Elasticsearch usage</td>
-<td colspan="1">`true`</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.client`</td>
-<td colspan="1">Choose between TransportClient and RestClient protocols</td>
-<td colspan="1">`TransportClient`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.indexName`</td>
-<td colspan="1">Name of the Elasticsearch index for the default document repository</td>
-<td colspan="1">`nuxeo`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.addressList`</td>
-<td colspan="1">For TransportClient protocol a comma separated list of Elasticsearch node `host:port`.
-For RestClient protocol a comma separated list of URL. If empty an in JVM embedded Elasticsearch node is used, the embedded node is only for testing and it is not supported for production.</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.clusterName`</td>
-<td colspan="1">Name of the Elasticsearch cluster to join when using a TranportClient protocol</td>
-<td colspan="1">`nuxeoCluster`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.indexNumberOfReplicas`</td>
-<td colspan="1">Number of replicas (not for local node)</td>
-<td colspan="1">`1`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.indexNumberOfShards`</td>
-<td colspan="1">Number of shards (not for local node)</td>
-<td colspan="1">`5`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.nodeName`</td>
-<td colspan="1">Name of the local node</td>
-<td colspan="1">`nuxeoNode`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.httpEnabled`</td>
-<td colspan="1">Does the local node accept HTTP request on port 9200</td>
-<td colspan="1">`false`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.override.pageproviders`</td>
-<td colspan="1">Comma separated list of CorePageProvider names to supersede by Elasticsearch</td>
-<td colspan="1">`default_search,DEFAULT_DOCUMENT_SUGGESTION`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.reindex.bucketReadSize`</td>
-<td colspan="1">Reindexing option, number of documents to process per worker</td>
-<td colspan="1">`500`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.reindex.bucketWriteSize`</td>
-<td colspan="1">Reindexing option, number of documents to submit to Elasticsearch per bulk command</td>
-<td colspan="1">`50`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.indexing.maxThreads`</td>
-<td colspan="1">Maximum size of the indexing thread pool</td>
-<td colspan="1">`4`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.indexing.clearCompletedAfterSeconds`</td>
-<td colspan="1">Time to keep the completed indexing worker states</td>
-<td colspan="1">`90`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.adminCenter.displayClusterInfo`</td>
-<td colspan="1">Display Elasticsearch cluster and nodes information in the admin center @since 6.0-HF06, always true for embedded mode</td>
-<td colspan="1">`false`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.reindex.onStartup`</td>
-<td colspan="1">Reindex the repository content on startup if the index is empty</td>
-<td colspan="1">`false`</td>
-<td colspan="1">&nbsp;</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.restClient.connectionTimeoutMs`</td>
-<td colspan="1">A timeout in milliseconds until a connection is established</td>
-<td colspan="1">`5000`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.restClient.socketTimeoutMs`</td>
-<td colspan="1">A maximum period, in milliseconds, of inactivity between two consecutive data packets</td>
-<td colspan="1">`20000`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.restClient.username`</td>
-<td colspan="1">A username for client basic authentication</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since 9.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.restClient.password`</td>
-<td colspan="1">A password for client basic authentication</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since 9.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.restClient.keystorePath`</td>
-<td colspan="1">A path to a valid keystore</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since 9.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.restClient.keystorePassword`</td>
-<td colspan="1">The keystore password</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since 9.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.restClient.keystoreType`</td>
-<td colspan="1">The type of keystore, e.g. jks</td>
-<td colspan="1">Default Java system keystore type</td>
-<td colspan="1">Since 9.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`elasticsearch.index.translog.durability`</td>
-<td colspan="1">The translog durability for Elasticsearch indexes. To reduce disk IO and increase performance this can be tuned to `async`.</td>
-<td colspan="1">`request`</td>
-<td colspan="1">Since 10.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.directory.type`</td>
-<td colspan="1">Type of directory, used for LDAP or multi-directory configuration. Possible values are `default`, `ldap`, `multi`.</td>
-<td colspan="1">`default`</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.user.anonymous.enable`</td>
-<td colspan="1">When LDAP is enabled and this parameter is set to `true`, allows anonymous login with `Guest` user</td>
-<td colspan="1">`false`</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.user.emergency.enable`</td>
-<td colspan="1">When LDAP is enabled and this parameter is set to `true`, declares an emergency user to connect to Nuxeo in case of LDAP issues</td>
-<td colspan="1">`false`</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.user.emergency.username`</td>
-<td colspan="1">The username of emergency user when `nuxeo.user.emergency.enable` is set to `true`</td>
-<td colspan="1">`MyAdministrator`</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.user.emergency.password`</td>
-<td colspan="1">The password of emergency user when `nuxeo.user.emergency.enable` is set to `true`</td>
-<td colspan="1">`secret`</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.user.emergency.firstname`</td>
-<td colspan="1">The firstname of emergency user when `nuxeo.user.emergency.enable` is set to `true`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.user.emergency.lastname`</td>
-<td colspan="1">The lastname of emergency user when `nuxeo.user.emergency.enable` is set to `true`</td>
-<td colspan="1">&nbsp;</td>
-<td colspan="1">Since 6.0</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.picture.migration.enabled`</td>
-<td colspan="1">When set to `false` allows to disable the picture migration that is run on startup and that can be slow on big volume.</td>
-<td colspan="1">`true`</td>
-<td colspan="1">Since 8.10</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.dbs.cache.enabled`</td>
-<td colspan="1">Whether or not the cache is enabled</td>
-<td colspan="1">`true`</td>
-<td colspan="1">Since 8.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.dbs.cache.concurrencyLevel`</td>
-<td colspan="1">Guava cache parameter: Guides the allowed concurrency among update operations. Used as a hint for internal sizing. The table is internally partitioned to try to permit the indicated number of concurrent updates without contention. Because assignment of entries to these partitions is not necessarily uniform, the actual concurrency observed may vary. Ideally, you should choose a value to accommodate as many threads as will ever concurrently modify the table. Using a significantly higher value than you need can waste space and time, and a significantly lower value can lead to thread contention. But overestimates and underestimates within an order of magnitude do not usually have much noticeable impact. A value of one permits only one thread to modify the cache at a time, but since read operations and cache loading computations can proceed concurrently, this still yields higher concurrency than full synchronization.</td>
-<td colspan="1">`10`</td>
-<td colspan="1">Since 8.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.dbs.cache.maxSize`</td>
-<td colspan="1">The maximum size of DBS cache</td>
-<td colspan="1">`1000`</td>
-<td colspan="1">Since 8.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.dbs.cache.ttl`</td>
-<td colspan="1">The expire after write value in minutes</td>
-<td colspan="1">`10`</td>
-<td colspan="1">Since 8.10-HF01</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.enabled`</td>
-<td colspan="1">Switch the default Stream configuration to Apache Kafka</td>
-<td colspan="1">`false`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.zkServers`</td>
-<td colspan="1">Deprecated since 10.2, 9.10-HF04, Nuxeo don't need Zookeeper access</td>
-<td colspan="1">`localhost:2181`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.bootstrap.servers`</td>
-<td colspan="1">host:port comma separated list of Kafka Brokers</td>
-<td colspan="1">`localhost:9092`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.default.replication.factor`</td>
-<td colspan="1">Default replication factor per partition when creating a new Topic</td>
-<td colspan="1">`1`</td>
-<td colspan="1">Since 10.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.topicPrefix`</td>
-<td colspan="1">The prefix applied to any Kafka Topic</td>
-<td colspan="1">`nuxeo-`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.request.timeout.ms`</td>
-<td colspan="1">Request timeout between Nuxeo and a Kafka broker</td>
-<td colspan="1">`30000`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.default.api.timeout.ms`</td>
-<td colspan="1">Default timeout for consumer API related to position</td>
-<td colspan="1">`120000`</td>
-<td colspan="1">Since 11.1, 10.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.max.poll.interval.ms`</td>
-<td colspan="1">Maximum delay between poll invocation</td>
-<td colspan="1">`7200000`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.max.poll.records`</td>
-<td colspan="1">Maximum number of records to read per poll</td>
-<td colspan="1">`2`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.session.timeout.ms`</td>
-<td colspan="1">Consumers that don't send heartbeat during this delay are removed from the group</td>
-<td colspan="1">`50000`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.heartbeat.interval.ms`</td>
-<td colspan="1">Heartbeat interval</td>
-<td colspan="1">`4000`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.delivery.timeout.ms`</td>
-<td colspan="1">Timeout for a producer to get an acknowledgement</td>
-<td colspan="1">`120000`</td>
-<td colspan="1">Since 11.1, 10.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.acks`</td>
-<td colspan="1">The number of acknowledgments expected by a producer</td>
-<td colspan="1">`1`</td>
-<td colspan="1">Since 11.1, 10.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.sasl.enabled`</td>
-<td colspan="1">Enable SASL authentication to communicate with Kafka brokers</td>
-<td colspan="1">`false`</td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.security.protocol`</td>
-<td colspan="1">When using SASL authentication, choose the protocol to communicate with brokers, valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL</td>
-<td colspan="1">`SASL_PLAINTEXT`</td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.sasl.mechanism`</td>
-<td colspan="1">SASL mechanism used for client connections</td>
-<td colspan="1">`SCRAM-SHA-256`</td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.sasl.jaas.config`</td>
-<td colspan="1">JAAS login context parameters for SASL connections in the format used by JAAS configuration files. See [Kafka documentation for more information](https://kafka.apache.org/documentation/#security_sasl_scram_clientconfig).</td>
-<td colspan="1"></td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.ssl`</td>
-<td colspan="1">Use SSL to communicate with Kafka Broker</td>
-<td colspan="1">`false`</td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.truststore.path`</td>
-<td colspan="1">The location of the trust store file, empty path means no truststore</td>
-<td colspan="1"></td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.truststore.type`</td>
-<td colspan="1">The file format of the trust store file</td>
-<td colspan="1">`JKS`</td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.truststore.password`</td>
-<td colspan="1">The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled</td>
-<td colspan="1"></td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.keystore.path`</td>
-<td colspan="1">The location of the key store file used by the client for two-way authentication, empty value means no keystore</td>
-<td colspan="1"></td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.keystore.type`</td>
-<td colspan="1">The file format of the key store file</td>
-<td colspan="1">`JKS`</td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
-<tr>
-<td colspan="1">`kafka.keystore.password`</td>
-<td colspan="1">The store password for the key store file</td>
-<td colspan="1"></td>
-<td colspan="1">Since 10.3/9.10-HF22</td>
-</tr>
+Example: https://my.nuxeo.com/
 
-<tr>
-<td colspan="1">`nuxeo.stream.chronicle.dir`</td>
-<td colspan="1">The directory where Chronicle Queue files are stored.</td>
-<td colspan="1">`${nuxeo.data.dir}/data/stream`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.chronicle.retention.duration`</td>
-<td colspan="1">Default retention for Chronicle Queue Log, default to 4 days.</td>
-<td colspan="1">`4d`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.audit.enabled`</td>
-<td colspan="1">Enable the Nuxeo Stream Audit Writer implementation</td>
-<td colspan="1">`true`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.audit.log.config`</td>
-<td colspan="1">The Log configuration to use for the Stream Audit Writer</td>
-<td colspan="1">`audit`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.audit.batch.size`</td>
-<td colspan="1">The entries batch size to submit the the audit backend</td>
-<td colspan="1">`25`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.audit.batch.threshold.ms`</td>
-<td colspan="1">Do not wait more than this threshold if the batch is not full</td>
-<td colspan="1">`500`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.enabled`</td>
-<td colspan="1">Supersed the default WorkManager with the Sream WorkManager</td>
-<td colspan="1">`false`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.log.config`</td>
-<td colspan="1">The Log configuration to use for the Stream WorkManager</td>
-<td colspan="1">`work`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.over.provisioning.factor`</td>
-<td colspan="1">The factor to use on the Work Thread pool size to get the number of Log partition.</td>
-<td colspan="1">`3`</td>
-<td colspan="1">Since 9.3</td>
-</tr>
+#### `elasticsearch.enabled`
 
-<tr>
-<td colspan="1">`nuxeo.stream.work.computation.filter.enabled`</td>
-<td colspan="1">Filter work with a serialized size that exceed a threshold so they are stored outside of the stream.</td>
-<td colspan="1">`false`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.computation.filter.thresholdSize`</td>
-<td colspan="1">Threshold in bytes that is used to store work outside of the stream.</td>
-<td colspan="1">`1000000`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.computation.filter.class`</td>
-<td colspan="1">The class that implement the external storage of large work. Default is using a Transient store, there is also a KeyValue implementation `org.nuxeo.ecm.core.work.KeyValueStoreOverflowRecordFilter`.</td>
-<td colspan="1">`org.nuxeo.ecm.core.transientstore.computation.TransientStoreOverflowRecordFilter`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.computation.filter.storeName`</td>
-<td colspan="1">The storage name to use.</td>
-<td colspan="1">`default`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.computation.filter.storeKeyPrefix`</td>
-<td colspan="1">A key prefix to use on the external storage.</td>
-<td colspan="1">`bigRecord:`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
-<tr>
-<td colspan="1">`nuxeo.stream.work.computation.filter.storeTTL`</td>
-<td colspan="1">The time to live used the KeyValue storage implementation.
-This does not apply to the Transient store where the retention is fixed by its configuration.</td>
-<td colspan="1">`4d`</td>
-<td colspan="1">Since 9.10</td>
-</tr>
+**Since 6.0**
 
-<tr>
-<td colspan="1">`org.nuxeo.runtime.reload_strategy`</td>
-<td colspan="1">
+Switch to enable/disable Elasticsearch usage
+
+_Default value:_ `true`
+
+#### `elasticsearch.client`
+
+**Since 9.3**
+
+Choose between TransportClient and RestClient protocols
+
+_Default value:_ `TransportClient`
+
+#### `elasticsearch.indexName`
+
+Name of the Elasticsearch index for the default document repository
+
+_Default value:_ `nuxeo`
+
+#### `elasticsearch.addressList`
+
+For TransportClient protocol a comma separated list of Elasticsearch node `host:port`.
+For RestClient protocol a comma separated list of URL. If empty an in JVM embedded Elasticsearch node is used, the embedded node is only for testing and it is not supported for production.
+
+#### `elasticsearch.clusterName`
+
+Name of the Elasticsearch cluster to join when using a TranportClient protocol
+
+_Default value:_ `nuxeoCluster`
+
+#### `elasticsearch.indexNumberOfReplicas`
+
+Number of replicas (not for local node)
+
+_Default value:_ `1`
+
+#### `elasticsearch.indexNumberOfShards`
+
+Number of shards (not for local node)
+
+_Default value:_ `5`
+
+#### `elasticsearch.nodeName`
+
+Name of the local node
+
+_Default value:_ `nuxeoNode`
+
+#### `elasticsearch.httpEnabled`
+
+Does the local node accept HTTP request on port 9200
+
+_Default value:_ `false`
+
+#### `elasticsearch.override.pageproviders`
+
+Comma separated list of CorePageProvider names to supersede by Elasticsearch
+
+_Default value:_ `default_search,DEFAULT_DOCUMENT_SUGGESTION`
+
+#### `elasticsearch.reindex.bucketReadSize`
+
+Reindexing option, number of documents to process per worker
+
+_Default value:_ `500`
+
+#### `elasticsearch.reindex.bucketWriteSize`
+
+Reindexing option, number of documents to submit to Elasticsearch per bulk command
+
+_Default value:_ `50`
+
+#### `elasticsearch.indexing.maxThreads`
+
+Maximum size of the indexing thread pool
+
+_Default value:_ `4`
+
+#### `elasticsearch.indexing.clearCompletedAfterSeconds`
+
+Time to keep the completed indexing worker states
+
+_Default value:_ `90`
+
+#### `elasticsearch.adminCenter.displayClusterInfo`
+
+Display Elasticsearch cluster and nodes information in the admin center @since 6.0-HF06, always true for embedded mode
+
+_Default value:_ `false`
+
+#### `elasticsearch.reindex.onStartup`
+
+Reindex the repository content on startup if the index is empty
+
+_Default value:_ `false`
+
+#### `elasticsearch.restClient.connectionTimeoutMs`
+
+**Since 9.10**
+
+A timeout in milliseconds until a connection is established
+
+_Default value:_ `5000`
+
+#### `elasticsearch.restClient.socketTimeoutMs`
+
+**Since 9.10**
+
+A maximum period, in milliseconds, of inactivity between two consecutive data packets
+
+_Default value:_ `20000`
+
+#### `elasticsearch.restClient.username`
+
+**Since 9.10-HF01**
+
+A username for client basic authentication
+
+#### `elasticsearch.restClient.password`
+
+**Since 9.10-HF01**
+
+A password for client basic authentication
+
+#### `elasticsearch.restClient.keystorePath`
+
+**Since 9.10-HF01**
+
+A path to a valid keystore
+
+#### `elasticsearch.restClient.keystorePassword`
+
+**Since 9.10-HF01**
+
+The keystore password
+
+#### `elasticsearch.restClient.keystoreType`
+
+**Since 9.10-HF01**
+
+The type of keystore, e.g. jks
+
+_Default value:_ Default Java system keystore type
+
+#### `elasticsearch.index.translog.durability`
+
+**Since 10.3**
+
+The translog durability for Elasticsearch indexes. To reduce disk IO and increase performance this can be tuned to `async`.
+
+_Default value:_ `request`
+
+#### `nuxeo.directory.type`
+
+**Since 6.0**
+
+Type of directory, used for LDAP or multi-directory configuration. Possible values are `default`, `ldap`, `multi`.
+
+_Default value:_ `default`
+
+#### `nuxeo.user.anonymous.enable`
+
+**Since 6.0**
+
+When LDAP is enabled and this parameter is set to `true`, allows anonymous login with `Guest` user
+
+_Default value:_ `false`
+
+#### `nuxeo.user.emergency.enable`
+
+**Since 6.0**
+
+When LDAP is enabled and this parameter is set to `true`, declares an emergency user to connect to Nuxeo in case of LDAP issues
+
+_Default value:_ `false`
+
+#### `nuxeo.user.emergency.username`
+
+**Since 6.0**
+
+The username of emergency user when `nuxeo.user.emergency.enable` is set to `true`
+
+_Default value:_ `MyAdministrator`
+
+#### `nuxeo.user.emergency.password`
+
+**Since 6.0**
+
+The password of emergency user when `nuxeo.user.emergency.enable` is set to `true`
+
+_Default value:_ `secret`
+
+#### `nuxeo.user.emergency.firstname`
+
+**Since 6.0**
+
+The firstname of emergency user when `nuxeo.user.emergency.enable` is set to `true`
+
+#### `nuxeo.user.emergency.lastname`
+
+**Since 6.0**
+
+The lastname of emergency user when `nuxeo.user.emergency.enable` is set to `true`
+
+#### `nuxeo.picture.migration.enabled`
+
+**Since 8.10**
+
+When set to `false` allows to disable the picture migration that is run on startup and that can be slow on big volume.
+
+_Default value:_ `true`
+
+#### `nuxeo.dbs.cache.enabled`
+
+**Since 8.10-HF01**
+
+Whether or not the cache is enabled
+
+_Default value:_ `true`
+
+#### `nuxeo.dbs.cache.concurrencyLevel`
+
+**Since 8.10-HF01**
+
+Guava cache parameter: Guides the allowed concurrency among update operations. Used as a hint for internal sizing. The table is internally partitioned to try to permit the indicated number of concurrent updates without contention. Because assignment of entries to these partitions is not necessarily uniform, the actual concurrency observed may vary. Ideally, you should choose a value to accommodate as many threads as will ever concurrently modify the table. Using a significantly higher value than you need can waste space and time, and a significantly lower value can lead to thread contention. But overestimates and underestimates within an order of magnitude do not usually have much noticeable impact. A value of one permits only one thread to modify the cache at a time, but since read operations and cache loading computations can proceed concurrently, this still yields higher concurrency than full synchronization.
+
+_Default value:_ `10`
+
+#### `nuxeo.dbs.cache.maxSize`
+
+**Since 8.10-HF01**
+
+The maximum size of DBS cache
+
+_Default value:_ `1000`
+
+#### `nuxeo.dbs.cache.ttl`
+
+**Since 8.10-HF01**
+
+The expire after write value in minutes
+
+_Default value:_ `10`
+
+#### `kafka.enabled`
+
+**Since 9.3**
+
+Switch the default Stream configuration to Apache Kafka
+
+_Default value:_ `false`
+
+#### `kafka.zkServers`
+
+**Since 9.3**
+
+Deprecated since 10.2, 9.10-HF04, Nuxeo don't need Zookeeper access
+
+_Default value:_ `localhost:2181`
+
+#### `kafka.bootstrap.servers`
+
+**Since 9.3**
+
+host:port comma separated list of Kafka Brokers
+
+_Default value:_ `localhost:9092`
+
+#### `kafka.default.replication.factor`
+
+**Since 10.3**
+
+Default replication factor per partition when creating a new Topic
+
+_Default value:_ `1`
+
+#### `kafka.topicPrefix`
+
+**Since 9.3**
+
+The prefix applied to any Kafka Topic
+
+_Default value:_ `nuxeo-`
+
+#### `kafka.request.timeout.ms`
+
+**Since 9.3**
+
+Request timeout between Nuxeo and a Kafka broker
+
+_Default value:_ `30000`
+
+#### `kafka.default.api.timeout.ms`
+
+**Since 11.1, 10.10-HF22**
+
+Default timeout for consumer API related to position
+
+_Default value:_ `120000`
+
+#### `kafka.max.poll.interval.ms`
+
+**Since 9.3**
+
+Maximum delay between poll invocation
+
+_Default value:_ `7200000`
+
+#### `kafka.max.poll.records`
+
+**Since 9.3**
+
+Maximum number of records to read per poll
+
+_Default value:_ `2`
+
+#### `kafka.session.timeout.ms`
+
+**Since 9.3**
+
+Consumers that don't send heartbeat during this delay are removed from the group
+
+_Default value:_ `50000`
+
+#### `kafka.heartbeat.interval.ms`
+
+**Since 9.3**
+
+Heartbeat interval
+
+_Default value:_ `4000`
+
+#### `kafka.delivery.timeout.ms`
+
+**Since 11.1, 10.10-HF22**
+
+Timeout for a producer to get an acknowledgement
+
+_Default value:_ `120000`
+
+#### `kafka.acks`
+
+**Since 11.1, 10.10-HF22**
+
+The number of acknowledgments expected by a producer
+
+_Default value:_ `1`
+
+#### `kafka.sasl.enabled`
+
+**Since 10.3/9.10-HF22**
+
+Enable SASL authentication to communicate with Kafka brokers
+
+_Default value:_ `false`
+
+#### `kafka.security.protocol`
+
+**Since 10.3/9.10-HF22**
+
+When using SASL authentication, choose the protocol to communicate with brokers, valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
+
+_Default value:_ `SASL_PLAINTEXT`
+
+#### `kafka.sasl.mechanism`
+
+**Since 10.3/9.10-HF22**
+
+SASL mechanism used for client connections
+
+_Default value:_ `SCRAM-SHA-256`
+
+#### `kafka.sasl.jaas.config`
+
+**Since 10.3/9.10-HF22**
+
+JAAS login context parameters for SASL connections in the format used by JAAS configuration files. See [Kafka documentation for more information](https://kafka.apache.org/documentation/#security_sasl_scram_clientconfig).
+
+_Default value:_
+
+#### `kafka.ssl`
+
+**Since 10.3/9.10-HF22**
+
+Use SSL to communicate with Kafka Broker
+
+_Default value:_ `false`
+
+#### `kafka.truststore.path`
+
+**Since 10.3/9.10-HF22**
+
+The location of the trust store file, empty path means no truststore
+
+_Default value:_
+
+#### `kafka.truststore.type`
+
+**Since 10.3/9.10-HF22**
+
+The file format of the trust store file
+
+_Default value:_ `JKS`
+
+#### `kafka.truststore.password`
+
+**Since 10.3/9.10-HF22**
+
+The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled
+
+_Default value:_
+
+#### `kafka.keystore.path`
+
+**Since 10.3/9.10-HF22**
+
+The location of the key store file used by the client for two-way authentication, empty value means no keystore
+
+_Default value:_
+
+#### `kafka.keystore.type`
+
+**Since 10.3/9.10-HF22**
+
+The file format of the key store file
+
+_Default value:_ `JKS`
+
+#### `kafka.keystore.password`
+
+**Since 10.3/9.10-HF22**
+
+The store password for the key store file
+
+_Default value:_
+
+#### `nuxeo.stream.chronicle.dir`
+
+**Since 9.3**
+
+The directory where Chronicle Queue files are stored.
+
+_Default value:_ `${nuxeo.data.dir}/data/stream`
+
+#### `nuxeo.stream.chronicle.retention.duration`
+
+**Since 9.3**
+
+Default retention for Chronicle Queue Log, default to 4 days.
+
+_Default value:_ `4d`
+
+#### `nuxeo.stream.audit.enabled`
+
+**Since 9.3**
+
+Enable the Nuxeo Stream Audit Writer implementation
+
+_Default value:_ `true`
+
+#### `nuxeo.stream.audit.log.config`
+
+**Since 9.3**
+
+The Log configuration to use for the Stream Audit Writer
+
+_Default value:_ `audit`
+
+#### `nuxeo.stream.audit.batch.size`
+
+**Since 9.3**
+
+The entries batch size to submit the the audit backend
+
+_Default value:_ `25`
+
+#### `nuxeo.stream.audit.batch.threshold.ms`
+
+**Since 9.3**
+
+Do not wait more than this threshold if the batch is not full
+
+_Default value:_ `500`
+
+#### `nuxeo.stream.work.enabled`
+
+**Since 9.3**
+
+Supersed the default WorkManager with the Sream WorkManager
+
+_Default value:_ `false`
+
+#### `nuxeo.stream.work.log.config`
+
+**Since 9.3**
+
+The Log configuration to use for the Stream WorkManager
+
+_Default value:_ `work`
+
+#### `nuxeo.stream.work.over.provisioning.factor`
+
+**Since 9.3**
+
+The factor to use on the Work Thread pool size to get the number of Log partition.
+
+_Default value:_ `3`
+
+#### `nuxeo.stream.work.computation.filter.enabled`
+
+**Since 9.10**
+
+Filter work with a serialized size that exceed a threshold so they are stored outside of the stream.
+
+_Default value:_ `false`
+
+#### `nuxeo.stream.work.computation.filter.thresholdSize`
+
+**Since 9.10**
+
+Threshold in bytes that is used to store work outside of the stream.
+
+_Default value:_ `1000000`
+
+#### `nuxeo.stream.work.computation.filter.class`
+
+**Since 9.10**
+
+The class that implement the external storage of large work. Default is using a Transient store, there is also a KeyValue implementation `org.nuxeo.ecm.core.work.KeyValueStoreOverflowRecordFilter`.
+
+_Default value:_ `org.nuxeo.ecm.core.transientstore.computation.TransientStoreOverflowRecordFilter`
+
+#### `nuxeo.stream.work.computation.filter.storeName`
+
+**Since 9.10**
+
+The storage name to use.
+
+_Default value:_ `default`
+
+#### `nuxeo.stream.work.computation.filter.storeKeyPrefix`
+
+**Since 9.10**
+
+A key prefix to use on the external storage.
+
+_Default value:_ `bigRecord:`
+
+#### `nuxeo.stream.work.computation.filter.storeTTL`
+
+**Since 9.10**
+
+The time to live used the KeyValue storage implementation.
+This does not apply to the Transient store where the retention is fixed by its configuration.
+
+_Default value:_ `4d`
+
+#### `org.nuxeo.runtime.reload_strategy`
+
+**Since 9.2**
+
 The strategy to use when hot reloading Nuxeo Server.<br/>
 There're two possible values, changing slightly the before/after reload logic:
+
 <ul>
 <li>`standby`: components are stopped, new/former components are deployed/undeployed, components are started</li>
 <li>`restart`: components are stopped, then de-activated, new/former components are deployed/undeployed, components are activated, then started</li>
 </ul>
-</td>
-<td colspan="1">`standby`</td>
-<td colspan="1">Since 9.2</td>
-</tr>
 
-</tbody>
-</table>
-</div>
+_Default value:_ `standby`
 
 <div class="row" data-equalizer data-equalize-on="medium"><div class="column medium-6">{{#> panel heading='Related content'}}
 


### PR DESCRIPTION
It would probably be worth grouping the properties in heading sections to make the TOC more usable.

Where there are multiple default values I would put them into a list starting on a new line.

Also, there are a few references to JBoss, not sure if these are relevant or useful?