### PR TITLE
Fix malformed JSON

### DIFF
--- a/src/nxdoc/web-ui/web-ui-functional-testing.md
+++ b/src/nxdoc/web-ui/web-ui-functional-testing.md
@@ -92,7 +92,7 @@ To ensure that you can access *SNAPSHOT* versions of the framework, you need to 
 {{#> panel type='code' heading='~/.npmrc'}}
 ```
 ...
-@nuxeo:registry=https://mavenin.nuxeo.com/nexus/repository/npmjs-nuxeo/
+@nuxeo:registry=https://packages.nuxeo.com/repository/npm-public-archives/
 ...
 ```
 {{/panel}}

--- a/src/nxdoc/web-ui/web-ui-functional-testing.md
+++ b/src/nxdoc/web-ui/web-ui-functional-testing.md
@@ -76,7 +76,7 @@ To use the framework on custom projects, you need to create an npm package with 
   "version": "1.0.0",
   "scripts": {
     "test": "nuxeo-web-ui-ftest --report --screenshots",
-    "test:watch": "nuxeo-web-ui-ftest --tags=@watch",
+    "test:watch": "nuxeo-web-ui-ftest --tags=@watch"
   },
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
When copy/pasting the `package.json` file, we have this error 

```shell
npm ERR! code EJSONPARSE
npm ERR! file /Users/dmetzler/src/github.com/dmetzler/nuxeo-sample-ftest/package.json
npm ERR! JSON.parse Failed to parse json
npm ERR! JSON.parse Unexpected token } in JSON at position 181 while parsing near '...t --tags=@watch",
npm ERR! JSON.parse   },
npm ERR! JSON.parse   "license": "Apa...'
npm ERR! JSON.parse Failed to parse package.json data.
npm ERR! JSON.parse package.json must be actual JSON, not just JavaScript.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/dmetzler/.npm/_logs/2020-11-18T13_44_59_713Z-debug.log
```