### PR TITLE
NXDOC-2226: remove node version in elements tutorial

### DIFF
--- a/src/nxdoc/web-ui/nuxeo-elements.md
+++ b/src/nxdoc/web-ui/nuxeo-elements.md
@@ -92,6 +92,9 @@ These are:
   ```
   $ bower install --save nuxeo/nuxeo-dataviz-elements
   ```
+  
+When developing using Nuxeo Elements, make sure to set up your development environment according to the requirements described in the [Nuxeo Elements repository](https://github.com/nuxeo/nuxeo-elements/blob/master/README.md#dependencies).
+
 Nuxeo Elements' development is supported by several tools and strategies, to keep quality, performance and security in check.
 Please see the [Quality Assurance page]({{page page='quality-assurance'}}) for more information on this subject, and
 also our [Custom App Tutorial]({{page page='nuxeo-elements-tutorial'}}) for a quick introduction to development with Nuxeo Elements.

--- a/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
+++ b/src/nxdoc/web-ui/nuxeo-elements/nuxeo-elements-tutorial.md
@@ -29,10 +29,10 @@ Watch the related courses on Nuxeo University:</br>
 
 ## Requirements
 
-- **[Node.js](https://nodejs.org/)** is a JavaScript runtime built on Chrome's V8 JavaScript engine. Almost every tool out there for client-side development is built with Node.js and distributed with npm, the package manager for Node.js. Make sure you download and install your OS-specific version first (last verified versions for this tutorial are node v10.12.0 and npm 6.4.1)
+- **[Node.js](https://nodejs.org/)** is a JavaScript runtime built on Chrome's V8 JavaScript engine. Almost every tool out there for client-side development is built with Node.js and distributed with npm, the package manager for Node.js. Make sure you download and install your OS-specific version first, according to the requirements described in the [Nuxeo Elements repository](https://github.com/nuxeo/nuxeo-elements/blob/master/README.md#dependencies).
 - **[Bower](http://bower.io/)** is currently **the** tool for managing web application definition.
-- **[Nuxeo CLI]({{page page='nuxeo-cli'}})** to scaffold your application **as a Nuxeo Bundle** and deploy it on a Nuxeo Server. Your application is **hosted inside** the Nuxeo Server as a bundle and uses it as a backend (last verified version for this tutorial is 1.9.0)
-- **[Polymer CLI](https://github.com/Polymer/tools/tree/master/packages/cli)** to scaffold your standalone application. Your application is **hosted outside** the Nuxeo Server and uses it as a service (last verified version for this tutorial is 1.9.5)
+- **[Nuxeo CLI]({{page page='nuxeo-cli'}})** to scaffold your application **as a Nuxeo Bundle** and deploy it on a Nuxeo Server. Your application is **hosted inside** the Nuxeo Server as a bundle and uses it as a backend (last verified version for this tutorial is 1.9.0).
+- **[Polymer CLI](https://github.com/Polymer/tools/tree/master/packages/cli)** to scaffold your standalone application. Your application is **hosted outside** the Nuxeo Server and uses it as a service (last verified version for this tutorial is 1.9.5).
 
 ## Scaffolding
 

--- a/src/nxdoc/web-ui/web-ui-overview.md
+++ b/src/nxdoc/web-ui/web-ui-overview.md
@@ -157,6 +157,7 @@ Edge, Firefox, and Chrome are called “evergreen browsers”: they are automati
 Nevertheless, Nuxeo is committed to using the latest supported version of the Polymer 2.X framework, provided by Google to the community, when it helps fixing bugs, especially against evergreen browsers.
 {{! /multiexcerpt}}
 
+When developing using Nuxeo Web UI, make sure to set up your development environment according to the requirements described in the [Nuxeo Web UI repository](https://github.com/nuxeo/nuxeo-web-ui/blob/master/README.md#install-dependencies).
 
 {{{multiexcerpt 'webui-functional-overview' space='userdoc' page='web-ui'}}}
 


### PR DESCRIPTION
Checking with @Gabez0r before creating backports for `2021` (v10.x), `1010` (v10.x) and `910` (v6.x).
- This is the only occurrence of node versions I could find in the doc.
- I don't think there's the need to include the npm version since the mapping is [publicly available](https://nodejs.org/en/download/releases/).
- Maybe we should also not include the "last verified versions for this tutorial" as we're now referencing just a major version instead of a maj.min.patch version.