### PR TITLE
Update elasticsearch default configuration

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
@@ -1189,7 +1189,7 @@ _Default value:_ `500`
 
 Reindexing option, number of documents to submit to Elasticsearch per bulk command
 
-_Default value:_ `50`
+_Default value:_ `100`
 
 #### `elasticsearch.indexing.maxThreads`
 
@@ -1221,7 +1221,7 @@ _Default value:_ `false`
 
 A timeout in milliseconds until a connection is established
 
-_Default value:_ `5000`
+_Default value:_ `30000`
 
 #### `elasticsearch.restClient.socketTimeoutMs`
 


### PR DESCRIPTION
We noticed differences between the documentation and the values set on the nuxeo.defaults, this is a simple update.
See: https://github.com/nuxeo/nuxeo/blob/35623ac199ba14e51d2a3d9228b8cd6715ee1881/server/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults#L133

Can be applied in 10.10 and 9.10 version, see https://jira.nuxeo.com/browse/NXP-23761