### PR TITLE
Update tomcat-server-zip.md

### DIFF
--- a/src/nxdoc/nuxeo-server/installation/tomcat-server-zip.md
+++ b/src/nxdoc/nuxeo-server/installation/tomcat-server-zip.md
@@ -137,7 +137,7 @@ Java packages and instructions for installation are available from the Azul webs
 
 As for any software, we very strongly recommend upgrading to the latest bugfix version of the JDK for any given major version.
 
-After installing the Java Development Kit, verify that the JAVA_HOME system variable correctly points to the Java Development Kit intended for running the Nuxeo Platform.   JAVA_HOME should be set if it is not present.
+After installing the Java Development Kit, verify that the `JAVA_HOME` system variable correctly points to the Java Development Kit intended for running the Nuxeo Platform (`JAVA_HOME` should be set if it is not present).
 
 {{! /multiexcerpt}}
 

--- a/src/nxdoc/nuxeo-server/installation/tomcat-server-zip.md
+++ b/src/nxdoc/nuxeo-server/installation/tomcat-server-zip.md
@@ -135,7 +135,9 @@ Java packages and instructions for installation are available from the Azul webs
 - [Download](https://www.azul.com/downloads/zulu-community/?architecture=x86-64-bit&package=jdk)
 - [Instructions](https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/Title.htm)
 
-As for any software, we very strongly recommend upgrading to the latest bugfix version of the JDK for any given major version
+As for any software, we very strongly recommend upgrading to the latest bugfix version of the JDK for any given major version.
+
+After installing the Java Development Kit, verify that the JAVA_HOME system variable correctly points to the Java Development Kit intended for running the Nuxeo Platform.   JAVA_HOME should be set if it is not present.
 
 {{! /multiexcerpt}}
 


### PR DESCRIPTION
Setting and verifying JAVA_HOME should be a pre-requisite since nuxeoctl.bat will not successfully determine JAVA_HOME with its current scripting resulting in a start failure with no log output to indicate the cause of the failure.

Azul Zulu JDK 11 install does not set JAVA_HOME, so it should be done manually.
Conflicts can also occur when JAVA_HOME points to an inappropriate JDK path.

Including the recommendation to verify JAVA_HOME in the Installing JDK section seems the most effective, though an alternative would be enhancing the Checking Your Java Version to include checking JAVA_HOME.