### PR TITLE
Change example operator for NXDOC-2336

### DIFF
--- a/src/nxdoc/nuxeo-server/data-store/persistence-architecture/file-storage.md
+++ b/src/nxdoc/nuxeo-server/data-store/persistence-architecture/file-storage.md
@@ -392,7 +392,7 @@ For example, all the videos could be stored somewhere, the attachments in a diff
     <class>org.nuxeo.ecm.core.blob.DefaultBlobDispatcher</class>
     <property name="dc:format=video">videos</property>
     <property name="blob:mime-type=video/mp4">videos</property>
-    <property name="blob:xpath=files/*/file">attachments</property>
+    <property name="blob:xpath~files/*/file">attachments</property>
     <property name="dc:source=secret">encrypted</property>
     <property name="default">default</property>
   </blobdispatcher>


### PR DESCRIPTION
The example here has:
    `<property name="blob:xpath=files/*/file">attachments</property>`
The correct operator for glob match should be `~`:
    `<property name="blob:xpath~files/*/file">attachments</property>`