### PR TITLE
NXDOC-2358 NXDOC-2357 Web UI release notes up to 3.0.6

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/variables-and-configuration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/variables-and-configuration/configuration-parameters-index-nuxeoconf.md
@@ -2276,6 +2276,19 @@ The limit is set at the transaction level (and not at the command level) because
 
 * * *
 
+### `nuxeo.selection.selectAllEnabled`
+
+Enables users to select all documents from results listings in the UI and to execute a bulk action on them. Learn more with the [bulk actions documentation]({{page page='web-ui-bulk-actions'}}).
+
+**Since LTS 2021.7**
+
+**Requires the Web UI package in version 3.0.6 or above**
+
+**Default Value**
+
+`false`
+
+* * *
 
 <div class="row" data-equalizer data-equalize-on="medium">
 <div class="column medium-6">

--- a/src/nxdoc/nuxeo-server/administration/variables-and-configuration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/variables-and-configuration/configuration-parameters-index-nuxeoconf.md
@@ -2276,7 +2276,7 @@ The limit is set at the transaction level (and not at the command level) because
 
 * * *
 
-### `nuxeo.selection.selectAllEnabled`
+#### `nuxeo.selection.selectAllEnabled`
 
 Enables users to select all documents from results listings in the UI and to execute a bulk action on them. Learn more with the [bulk actions documentation]({{page page='web-ui-bulk-actions'}}).
 

--- a/src/nxdoc/web-ui/web-ui-release-notes.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes.md
@@ -10,4 +10,20 @@ labels:
 tree_item_index: 500
 ---
 
-{{{multiexcerpt 'release-notes' page='web-ui-11-1-release-notes'}}}
+{{! multiexcerpt name='matching-notes'}}
+{{#> callout type='info' heading='Upgrade Notes'}}
+This page mentions what's new. Refer to the [upgrade notes]({{page page='nxdoc/cloud/web-ui-upgrade-notes'}}) to transition to this version.
+{{/callout}}
+{{! /multiexcerpt}}
+
+## Recently Released Changes
+
+{{{multiexcerpt 'web-ui-updates' page='web-ui-release-notes-3-0-6'}}}
+
+---
+
+## Previous Release Notes
+
+| Version                                                                       | Summary                                                                    |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [Web UI 3.0.0 to 3.0.5]({{page page='web-ui-release-notes-3-0-0-to-3-0-5'}})  | Upload experience for Large Files, audit entries improvements and more     |

--- a/src/nxdoc/web-ui/web-ui-release-notes.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes.md
@@ -12,7 +12,7 @@ tree_item_index: 500
 
 {{! multiexcerpt name='matching-notes'}}
 {{#> callout type='info' heading='Upgrade Notes'}}
-This page mentions what's new. Refer to the [upgrade notes]({{page page='nxdoc/cloud/web-ui-upgrade-notes'}}) to transition to this version.
+This page mentions what's new. Refer to the [upgrade notes]({{page page='web-ui-upgrade-notes'}}) to transition to this version.
 {{/callout}}
 {{! /multiexcerpt}}
 

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-0-to-3-0-5.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-0-to-3-0-5.md
@@ -1,6 +1,6 @@
 ---
-title: Nuxeo Web UI for LTS 2021 Release Notes
-description: Discover changes brought in our recent Nuxeo Web UI updates.
+title: Versions 3.0.0 to 3.0.5
+description: Discover what's new in Web UI 3.0.0 to 3.0.5.
 review:
     comment: ''
     date: '2021-09-02'
@@ -8,7 +8,6 @@ review:
 toc: true
 labels:
 tree_item_index: 999
-hidden: true
 ---
 
 {{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}
@@ -43,7 +42,7 @@ An effort has been started to improve Nuxeo Web UI's accessibility, the goal bei
 
 [[Solved Accessibility Issues](https://jira.nuxeo.com/issues/?jql="Epic Link" in %28'WEBUI-190'%2C 'WEBUI-193'%29 and resolution !%3D unresolved ORDER BY priority DESC)]
 
-### Advanced Validation Logic for Forms
+### Advanced Validation Logic For Forms
 
 Form validation offers advanced options:
 - Logic can be executed asynchronously to call a third party service
@@ -51,7 +50,7 @@ Form validation offers advanced options:
 
 [[NXP-28048](https://jira.nuxeo.com/browse/NXP-28048)]
 
-### Atomic Permissions for UI components
+### Atomic Permissions For UI Components
 
 Web UI checks for granular permissions in order to display components instead of high level permissions like "Read" or "Edit". This helps with keeping the UI accurate even if you reconfigured the permissions and how they should be made available to users.
 
@@ -75,7 +74,7 @@ Users can still scroll through the list of tasks as usual in order to retrieve m
 
 Web UI uses Polymer 3 instead of Polymer 2.
 
-This is a technical change that happens under the hood, and backwards compatibility is ensured for applications built on top of Nuxeo Web UI. For the technical details, refer to the [upgrade notes]({{page page='web-ui-11-1-upgrade-notes'}}).
+This is a technical change that happens under the hood, and backwards compatibility is ensured for applications built on top of Nuxeo Web UI. For the technical details, refer to the [upgrade notes]({{page page='web-ui-upgrade-notes-lts-2021'}}).
 
 ### Styling Improvements
 
@@ -99,11 +98,11 @@ The following elements were moved to the Nuxeo Elements library, improving their
 
 ### Other Noteworthy Items
 
-- Document creation and edit popups size can be changed using theme variables<br/> [[NXP-26938](https://jira.nuxeo.com/browse/NXP-26938)]
-- A configuration property can change navigation URLs to use the document ID instead of their path<br/> [[WEBUI-14](https://jira.nuxeo.com/browse/WEBUI-14)]
-- Portrait dimensioned videos are better handled in conversions<br/> [[NXP-28856](https://jira.nuxeo.com/browse/NXP-28856)]
-- When two people complete the same task, the second person is notified and taken to the document<br/> [[NXP-27462](https://jira.nuxeo.com/browse/NXP-27462)]
-- A UI component lets you switch between available repositories<br/> [[NXP-28999](https://jira.nuxeo.com/browse/NXP-28999)]
+- Document creation and edit popups size can be changed using theme variables.<br/> [[NXP-26938](https://jira.nuxeo.com/browse/NXP-26938)]
+- A configuration property can change navigation URLs to use the document ID instead of their path.<br/> [[WEBUI-14](https://jira.nuxeo.com/browse/WEBUI-14)]
+- Portrait dimensioned videos are better handled in conversions.<br/> [[NXP-28856](https://jira.nuxeo.com/browse/NXP-28856)]
+- When two people complete the same task, the second person is notified and taken to the document.<br/> [[NXP-27462](https://jira.nuxeo.com/browse/NXP-27462)]
+- A UI component lets you switch between available repositories.<br/> [[NXP-28999](https://jira.nuxeo.com/browse/NXP-28999)]
 
 ## Learn More
 

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-0-to-3-0-5.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-0-to-3-0-5.md
@@ -1,9 +1,9 @@
 ---
-title: Nuxeo Web UI 11.1 Release Notes
+title: Nuxeo Web UI for LTS 2021 Release Notes
 description: Discover changes brought in our recent Nuxeo Web UI updates.
 review:
     comment: ''
-    date: '2020-06-24'
+    date: '2021-09-02'
     status: ok
 toc: true
 labels:
@@ -11,26 +11,37 @@ tree_item_index: 999
 hidden: true
 ---
 
-{{! multiexcerpt name='release-notes'}}
+{{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}
 
-{{! multiexcerpt name='matching-notes'}}
-{{#> callout type='info' heading='Upgrade Notes'}}
-This page mentions what's new. Refer to the [upgrade notes]({{page page='nxdoc/cloud/web-ui-upgrade-notes'}}) to transition to this version.
-{{/callout}}
-{{! /multiexcerpt}}
+## What's New in Web UI for LTS 2021 (versions 3.0.0 to 3.0.5)
 
-## What's New in Web UI 11.1
-
+{{! multiexcerpt name='web-ui-updates'}}
 ### Upload Experience for Large Files
 
 Web UI provides a safe experience when uploading files, even for large files in the 75gb range and when the upload goes on for hours due to a slow connection.
 
 If a network problem happens, guidance is provided so that you can decide what to do with the situation: e.g. create the document anyway and upload the attachment later.
 
-- [NXP-29189](https://jira.nuxeo.com/browse/NXP-29189)
-- [NXP-28495](https://jira.nuxeo.com/browse/NXP-28495)
-- [NXP-27346](https://jira.nuxeo.com/browse/NXP-27346)
-- [NXP-27162](https://jira.nuxeo.com/browse/NXP-27162)
+- [[NXP-29189](https://jira.nuxeo.com/browse/NXP-29189)]
+- [[NXP-28495](https://jira.nuxeo.com/browse/NXP-28495)]
+- [[NXP-27346](https://jira.nuxeo.com/browse/NXP-27346)]
+- [[NXP-27162](https://jira.nuxeo.com/browse/NXP-27162)]
+
+### Configurable Header and Footer
+
+Web UI allows you to [configure a custom header and footer]({{page page='how-to-add-a-header-and-a-footer'}}) to display static and / or dynamic information on every page.
+
+[[WEBUI-306](https://jira.nuxeo.com/browse/WEBUI-306)]
+
+### Rich Text Editor Can Reference Images
+
+The rich text editor allows you to reference images stored in Nuxeo. This is useful to [leverage Nuxeo as a headless CMS]({{page page='how-to-use-rich-text-editor-rte-for-article-publishing'}}) for an article publishing use case typically. Additionally, most default buttons from QuillJS have been added to Web UI [[ELEMENTS-1379](https://jira.nuxeo.com/browse/ELEMENTS-1379)].
+
+### Accessibility Improvements
+
+An effort has been started to improve Nuxeo Web UI's accessibility, the goal being to reach full compliance with WCAG 2.1 level AA. This is a continuous effort, and many important issues have been fixed already.
+
+[[Solved Accessibility Issues](https://jira.nuxeo.com/issues/?jql="Epic Link" in %28'WEBUI-190'%2C 'WEBUI-193'%29 and resolution !%3D unresolved ORDER BY priority DESC)]
 
 ### Advanced Validation Logic for Forms
 
@@ -39,6 +50,12 @@ Form validation offers advanced options:
 - Server-side logic can also check the input and trigger an error that will be made visible to the user
 
 [[NXP-28048](https://jira.nuxeo.com/browse/NXP-28048)]
+
+### Atomic Permissions for UI components
+
+Web UI checks for granular permissions in order to display components instead of a high level one. This helps with keeping the UI accurate even if you reconfigured the permissions and how they should be made available to users.
+
+[[WEBUI-5](https://jira.nuxeo.com/browse/WEBUI-5)]
 
 ### Easier to Find and Read Audit Entries
 
@@ -90,5 +107,7 @@ The following elements were moved to the Nuxeo Elements library, improving their
 - A default HTML page is shown when no preview is available in Web UI</br> [[NXP-27648](https://jira.nuxeo.com/browse/NXP-27648)]
 - When two people complete the same task, the second person is notified and taken to the document</br> [[NXP-27462](https://jira.nuxeo.com/browse/NXP-27462)]
 
-This release also comes with over 160 bugs fixed, making Web UI more solid than ever.
+## Learn More
+
+[More information about released changes and fixed bugs](https://jira.nuxeo.com/issues/?jql=project IN %28'WEBUI', 'ELEMENTS'%29 AND fixVersion IN %28'3.0.0','3.0.1','3.0.2','3.0.3','3.0.4','3.0.5'%29 ORDER BY type DESC, priority DESC) is available in our bug tracking tool.
 {{! /multiexcerpt}}

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-0-to-3-0-5.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-0-to-3-0-5.md
@@ -53,7 +53,7 @@ Form validation offers advanced options:
 
 ### Atomic Permissions for UI components
 
-Web UI checks for granular permissions in order to display components instead of a high level one. This helps with keeping the UI accurate even if you reconfigured the permissions and how they should be made available to users.
+Web UI checks for granular permissions in order to display components instead of high level permissions like "Read" or "Edit". This helps with keeping the UI accurate even if you reconfigured the permissions and how they should be made available to users.
 
 [[WEBUI-5](https://jira.nuxeo.com/browse/WEBUI-5)]
 
@@ -99,13 +99,11 @@ The following elements were moved to the Nuxeo Elements library, improving their
 
 ### Other Noteworthy Items
 
-- Document creation and edit popups size can be changed using theme variables</br> [[NXP-26938](https://jira.nuxeo.com/browse/NXP-26938)]
-- When doing a bulk download, a notification is displayed until the download starts</br> [[NXP-28478](https://jira.nuxeo.com/browse/NXP-28478)]
-- Workflow analytics are clearer by showing a label for buttons pressed instead of an id</br> [[NXP-28338](https://jira.nuxeo.com/browse/NXP-28338)]
-- Portrait dimensioned videos are better handled in conversions</br> [[NXP-28856](https://jira.nuxeo.com/browse/NXP-28856)]
-- Document type name in the creation notification confirmation is translated</br> [[NXP-28533](https://jira.nuxeo.com/browse/NXP-28533)]
-- A default HTML page is shown when no preview is available in Web UI</br> [[NXP-27648](https://jira.nuxeo.com/browse/NXP-27648)]
-- When two people complete the same task, the second person is notified and taken to the document</br> [[NXP-27462](https://jira.nuxeo.com/browse/NXP-27462)]
+- Document creation and edit popups size can be changed using theme variables<br/> [[NXP-26938](https://jira.nuxeo.com/browse/NXP-26938)]
+- A configuration property can change navigation URLs to use the document ID instead of their path<br/> [[WEBUI-14](https://jira.nuxeo.com/browse/WEBUI-14)]
+- Portrait dimensioned videos are better handled in conversions<br/> [[NXP-28856](https://jira.nuxeo.com/browse/NXP-28856)]
+- When two people complete the same task, the second person is notified and taken to the document<br/> [[NXP-27462](https://jira.nuxeo.com/browse/NXP-27462)]
+- A UI component lets you switch between available repositories<br/> [[NXP-28999](https://jira.nuxeo.com/browse/NXP-28999)]
 
 ## Learn More
 

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
@@ -1,6 +1,6 @@
 ---
-title: Nuxeo Web UI for LTS 2021 Release Notes
-description: Discover changes brought in our recent Nuxeo Web UI updates.
+title: Version 3.0.6
+description: Discover what's new in Web UI 3.0.6.
 review:
     comment: ''
     date: '2021-09-02'
@@ -8,7 +8,6 @@ review:
 toc: true
 labels:
 tree_item_index: 998
-hidden: true
 ---
 
 {{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}
@@ -21,9 +20,9 @@ hidden: true
 
 This release introduces a first iteration for bulk actions. Users can now select all documents from a results listing both in a search or browsing context, then execute an action on them.
 
-Bulk actions can be executed on most default actions from Web UI like adding documents to a collection or publishing them. It is also possible to [create your custom bulk actions using Nuxeo Studio]({{page page='howto-create-bulk-actions-studio' space='studio'}}).
+Bulk actions can be executed on most default actions from Web UI like adding documents to a collection or publishing them. It is also possible to [create your custom bulk actions using Nuxeo Studio]({{page page='how-to-create-bulk-actions-studio'}}).
 
-This feature is currently disabled by default; you can activate it by adding the property `nuxeo.selection.selectAllEnabled=true` in your [nuxeo.conf](configuration-parameters-index-nuxeoconf) file. Learn more with the [bulk actions documentation]({{page page='web-ui-bulk-actions'}}).
+This feature is currently disabled by default; you can activate it by adding the property `nuxeo.selection.selectAllEnabled=true` in your [nuxeo.conf]({{page page='configuration-parameters-index-nuxeoconf'}}) file. Learn more with the [bulk actions documentation]({{page page='web-ui-bulk-actions'}}).
 
 [[WEBUI-248](https://jira.nuxeo.com/browse/WEBUI-248)]
 
@@ -41,8 +40,8 @@ We are keeping a compatilibity layer with NodeJS v10 and the Webdriver v4 API fo
 
 ### Other Noteworthy Changes
 
-- Web UI is now available in the Czech language. We would like to thank all the people who participated in that translation effort.<br />[[WEBUI-403](https://jira.nuxeo.com/browse/WEBUI-403)]
-- The HTML editor works properly in edit layouts and nuxeo-data-table-form. <br /> [[ELEMENTS-1393](https://jira.nuxeo.com/browse/ELEMENTS-1393)]
+- Web UI is now available in the Czech language. We would like to thank all the people who participated in that translation effort.<br/>[[WEBUI-403](https://jira.nuxeo.com/browse/WEBUI-403)]
+- The HTML editor works properly in edit layouts and nuxeo-data-table-form. <br/> [[ELEMENTS-1393](https://jira.nuxeo.com/browse/ELEMENTS-1393)]
 
 ## Learn More
 

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
@@ -17,7 +17,32 @@ hidden: true
 
 {{! multiexcerpt name='web-ui-updates'}}
 
-### //TODO
+### Execute Actions in Bulk
+
+This release introduces a first iteration for bulk actions. Users can now select all documents from a results listing both in a search or browsing context, then execute an action on them.
+
+Bulk actions can be executed on most default actions from Web UI like adding documents to a collection or publishing them. It is also possible to [create your custom bulk actions using Nuxeo Studio]({{page page='howto-create-bulk-actions-studio' space='studio'}}).
+
+This feature is currently disabled by default; you can activate it by adding the property `nuxeo.selection.selectAllEnabled=true` in your [nuxeo.conf](configuration-parameters-index-nuxeoconf) file. Learn more with the [bulk actions documentation]({{page page='web-ui-bulk-actions'}}).
+
+[[WEBUI-248](https://jira.nuxeo.com/browse/WEBUI-248)]
+
+### Webdriver IO v4 and NodeJS v10 Deprecated
+
+We migrated our functional tests to make use of Webdriver IO v7 and NodeJS v14.
+
+If your project contains functional tests, we encourage you to check whether they rely or not on the Webdriver v4 API or on NodeJS v10; both of these tools have been deprecated for a long time and you should migrate them as soon as you can.
+
+We recommend using the latest active LTS from NodeJS (v14 at the time of this writing). The minimal version for NodeJS becomes v12.
+
+We are keeping a compatilibity layer with NodeJS v10 and the Webdriver v4 API for now, and we intend to drop it: date is currently being determined. If your project relies on these, feel free to reach out to us so that we can discuss a path forward. You can do that through your customer success representative or directly by email: ui@nuxeo.com
+
+[[WEBUI-278](https://jira.nuxeo.com/browse/WEBUI-278)]
+
+### Other Noteworthy Changes
+
+- Web UI is now available in the Czech language. We would like to thank all the people who participated in that translation effort.<br />[[WEBUI-403](https://jira.nuxeo.com/browse/WEBUI-403)]
+- The HTML editor works properly in a nuxeo-data-table-form. <br /> [[ELEMENTS-1393](https://jira.nuxeo.com/browse/ELEMENTS-1393)]
 
 ## Learn More
 

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
@@ -1,0 +1,25 @@
+---
+title: Nuxeo Web UI for LTS 2021 Release Notes
+description: Discover changes brought in our recent Nuxeo Web UI updates.
+review:
+    comment: ''
+    date: '2021-09-02'
+    status: ok
+toc: true
+labels:
+tree_item_index: 998
+hidden: true
+---
+
+{{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}
+
+## What's New in Web UI for LTS 2021 (version 3.0.6)
+
+{{! multiexcerpt name='web-ui-updates'}}
+
+### //TODO
+
+## Learn More
+
+[More information about released changes and fixed bugs](https://jira.nuxeo.com/issues/?jql=project IN %28'WEBUI', 'ELEMENTS'%29 AND fixVersion IN %28'3.0.6'%29 ORDER BY type DESC, priority DESC) is available in our bug tracking tool.
+{{! /multiexcerpt}}

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-6.md
@@ -42,7 +42,7 @@ We are keeping a compatilibity layer with NodeJS v10 and the Webdriver v4 API fo
 ### Other Noteworthy Changes
 
 - Web UI is now available in the Czech language. We would like to thank all the people who participated in that translation effort.<br />[[WEBUI-403](https://jira.nuxeo.com/browse/WEBUI-403)]
-- The HTML editor works properly in a nuxeo-data-table-form. <br /> [[ELEMENTS-1393](https://jira.nuxeo.com/browse/ELEMENTS-1393)]
+- The HTML editor works properly in edit layouts and nuxeo-data-table-form. <br /> [[ELEMENTS-1393](https://jira.nuxeo.com/browse/ELEMENTS-1393)]
 
 ## Learn More
 

--- a/src/nxdoc/web-ui/web-ui-upgrade-notes.md
+++ b/src/nxdoc/web-ui/web-ui-upgrade-notes.md
@@ -3,11 +3,11 @@ title: Web UI Upgrade Notes
 description: Detailed upgrade notes to transition to the latest Web UI version.
 review:
     comment: ''
-    date: '2020-06-24'
+    date: '2021-09-02'
     status: ok
 toc: true
 labels:
 tree_item_index: 550
 ---
 
-{{{multiexcerpt 'upgrade-notes' page='web-ui-11-1-upgrade-notes'}}}
+{{{multiexcerpt 'upgrade-notes' page='web-ui-lts-2021-upgrade-notes'}}}

--- a/src/nxdoc/web-ui/web-ui-upgrade-notes.md
+++ b/src/nxdoc/web-ui/web-ui-upgrade-notes.md
@@ -10,4 +10,4 @@ labels:
 tree_item_index: 550
 ---
 
-{{{multiexcerpt 'upgrade-notes' page='web-ui-lts-2021-upgrade-notes'}}}
+{{{multiexcerpt 'upgrade-notes' page='web-ui-upgrade-notes-lts-2021'}}}

--- a/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-lts-2021-upgrade-notes.md
+++ b/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-lts-2021-upgrade-notes.md
@@ -1,9 +1,9 @@
 ---
-title: Upgrading Nuxeo Web UI from LTS 2019 to 11.x
-description: Upgrade notes from Nuxeo Web UI LTS 2019 (10.10) to 11.x
+title: Upgrading Nuxeo Web UI from LTS 2019 to LTS 2021
+description: Upgrade notes from Nuxeo Web UI LTS 2019 (10.10) to LTS 2021
 review:
     comment: ''
-    date: '2021-01-07'
+    date: '2021-09-02'
     status: ok
 toc: true
 labels:
@@ -19,7 +19,7 @@ This page mentions how to do a technical upgrade. Have a look at the [release no
 {{/callout}}
 {{! /multiexcerpt}}
 
-## Upgrading from Web UI LTS 2019 to Web UI 11.x
+## Upgrading Web UI from LTS 2019 to LTS 2021
 
 ### Polymer 3 Migration
 
@@ -120,6 +120,10 @@ Spreadsheet addon is now loaded by default but the button contribution is disabl
 ![Spreadsheet package enable button in Designer](nx_asset://b8fd28dd-0272-43b1-a083-dfde295c312b ?w=650,border=true)
 {{! /multiexcerpt}}
 
+### Rich Text Editor Uses QuillJS by Default
+
+<a href="https://quilljs.com" target="_blank">QuillJS</a> is used as the solution for the rich text editor in Web UI. This change is [available as an option](https://jira.nuxeo.com/browse/WEBUI-291) in LTS 2019 if you want your users to get accustomed to it before migrating.
+
 ### Breaking Changes
 
 #### BROWSER_ACTIONS Slot Removal
@@ -192,6 +196,6 @@ Since [ELEMENTS-1012](https://jira.nuxeo.com/browse/ELEMENTS-1012), `nuxeo-slot`
 
 ### Drop Support for Edge Legacy
 
-Starting from 11.x, Nuxeo Web UI no longer supports *Microsoft Edge Legacy*. See [here](https://doc.nuxeo.com/nxdoc/web-ui-overview/) for the complete list of supported browsers.
+Starting from LTS 2021, Nuxeo Web UI no longer supports *Microsoft Edge Legacy*. See [here](https://doc.nuxeo.com/nxdoc/web-ui-overview/) for the complete list of supported browsers.
 
 {{! /multiexcerpt}}

--- a/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-upgrade-notes-lts-2021.md
+++ b/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-upgrade-notes-lts-2021.md
@@ -128,6 +128,26 @@ In LTS 2019, this change is already [available as an option](https://jira.nuxeo.
 
 ### Breaking Changes
 
+#### Cropper.js no longer shipped by default on Web UI
+Cropper is no longer part of our dependencies, as was the case on previous versions o Web UI.
+
+In case your project has a dependency on it, please consider the following steps:
+1. Download the package from [cropper.js website](https://fengyuanchen.github.io/cropperjs/) and find two files called cropper.min.js and cropper.min.css;
+2. In your Studio project, switch to Designer and click on the "Resources" tab;
+3. Create a folder called "cropper" and upload cropper.min.js and cropper.min.css to it;
+4. In your main bundle, add the following code:
+    ```
+    <link rel="stylesheet" href="cropper/cropper.min.css">
+    <script src="cropper/cropper.min.js"></script>
+    ```
+5. Deploy the project to your server;
+6. Check on your browser dev tools for the presence of Cropper.js in the global namespace:
+    ```
+    window.Cropper;
+    ```
+
+The console should return Cropper.js main function, thus confirming the presence of the package in the project.
+
 #### BROWSER_ACTIONS Slot Removal
 
 The `BROWSER_ACTIONS` nuxeo slot was removed under [NXP-26184](https://jira.nuxeo.com/browse/NXP-26184). It was already deprecated since Web UI 0.9 and had no known usage. It was replaced by the `RESULTS_SELECTION_ACTIONS` slot.

--- a/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-upgrade-notes-lts-2021.md
+++ b/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-upgrade-notes-lts-2021.md
@@ -122,7 +122,9 @@ Spreadsheet addon is now loaded by default but the button contribution is disabl
 
 ### Rich Text Editor Uses QuillJS by Default
 
-<a href="https://quilljs.com" target="_blank">QuillJS</a> is used as the solution for the rich text editor in Web UI. This change is [available as an option](https://jira.nuxeo.com/browse/WEBUI-291) in LTS 2019 if you want your users to get accustomed to it before migrating.
+Since [ELEMENTS-1124](https://jira.nuxeo.com/browse/ELEMENTS-1124) and [NXP-28691](https://jira.nuxeo.com/browse/NXP-28691), <a href="https://quilljs.com" target="_blank">Quill</a> is used as the solution for the rich text editor in Web UI instead of Alloy. Quill is more powerful and provides an overall better experience.
+
+In LTS 2019, this change is already [available as an option](https://jira.nuxeo.com/browse/WEBUI-291). Feel free to activate it to test the editor and to allow your users to get accustomed to it before migrating.
 
 ### Breaking Changes
 
@@ -132,7 +134,7 @@ The `BROWSER_ACTIONS` nuxeo slot was removed under [NXP-26184](https://jira.nuxe
 
 #### Forked nuxeo-document-content Might Lose Selection Actions
 
-After [NXP-25345](https://jira.nuxeo.com/browse/NXP-25345), Nuxeo Web UI introduced the ability to override selection actions. Elements that were forked from an older version of `nuxeo-document-content` and that override the `selectionActions` native slot with new content will be missing the contributions to the `RESULTS_SELECTION_ACTIONS` nuxeo slot. This can be rectified by adding the desired actions to the new slot, and by deleting the following piece of code:
+Since [NXP-25345](https://jira.nuxeo.com/browse/NXP-25345), Nuxeo Web UI introduced the ability to override selection actions. Elements that were forked from an older version of `nuxeo-document-content` and that override the `selectionActions` native slot with new content will be missing the contributions to the `RESULTS_SELECTION_ACTIONS` nuxeo slot. This can be rectified by adding the desired actions to the new slot, and by deleting the following piece of code:
 
 ```
 <div slot=“selectionActions”>

--- a/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-upgrade-notes-lts-2021.md
+++ b/src/nxdoc/web-ui/web-ui-upgrade-notes/web-ui-upgrade-notes-lts-2021.md
@@ -15,7 +15,7 @@ hidden: true
 
 {{! multiexcerpt name='matching-notes'}}
 {{#> callout type='info' heading='Release Notes'}}
-This page mentions how to do a technical upgrade. Have a look at the [release notes]({{page page='nxdoc/cloud/web-ui-release-notes'}}) to see what's new.
+This page mentions how to do a technical upgrade. Have a look at the [release notes]({{page page='web-ui-release-notes'}}) to see what's new.
 {{/callout}}
 {{! /multiexcerpt}}
 
@@ -122,19 +122,20 @@ Spreadsheet addon is now loaded by default but the button contribution is disabl
 
 ### Rich Text Editor Uses QuillJS by Default
 
-Since [ELEMENTS-1124](https://jira.nuxeo.com/browse/ELEMENTS-1124) and [NXP-28691](https://jira.nuxeo.com/browse/NXP-28691), <a href="https://quilljs.com" target="_blank">Quill</a> is used as the solution for the rich text editor in Web UI instead of Alloy. Quill is more powerful and provides an overall better experience.
+Since [ELEMENTS-1124](https://jira.nuxeo.com/browse/ELEMENTS-1124) and [NXP-28691](https://jira.nuxeo.com/browse/NXP-28691), [Quill](https://quilljs.com) is used as the solution for the rich text editor in Web UI instead of Alloy. Quill is more powerful and provides an overall better experience.
 
 In LTS 2019, this change is already [available as an option](https://jira.nuxeo.com/browse/WEBUI-291). Feel free to activate it to test the editor and to allow your users to get accustomed to it before migrating.
 
 ### Breaking Changes
 
-#### Cropper.js no longer shipped by default on Web UI
-Cropper is no longer part of our dependencies, as was the case on previous versions o Web UI.
+#### Cropper.js No Longer Shipped by Default on Web UI
+
+Cropper is no longer part of our dependencies, as it was the case on previous versions of Web UI.
 
 In case your project has a dependency on it, please consider the following steps:
-1. Download the package from [cropper.js website](https://fengyuanchen.github.io/cropperjs/) and find two files called cropper.min.js and cropper.min.css;
+1. Download the package from [cropper.js website](https://fengyuanchen.github.io/cropperjs/) and find two files called `cropper.min.js` and `cropper.min.css`;
 2. In your Studio project, switch to Designer and click on the "Resources" tab;
-3. Create a folder called "cropper" and upload cropper.min.js and cropper.min.css to it;
+3. Create a folder called `cropper` and upload `cropper.min.js` and `cropper.min.css` to it;
 4. In your main bundle, add the following code:
     ```
     <link rel="stylesheet" href="cropper/cropper.min.css">
@@ -189,22 +190,26 @@ The use of `nuxeo-document-history` was deprecated in favor of `nuxeo-audit-sear
 
 Since [WEBUI-116](https://jira.nuxeo.com/browse/WEBUI-116), the `document history` and `audit page` use the same component and the new prefix `audit`. The following are some examples of the deprecated labels and their replacement:
 
-| Deprecated labels             | New Labels          |
-|-------------------------------|---------------------|
-| documentHistory.category      | audit.category      |
-| documentHistory.comment       | audit.comment       |
-| documentHistory.date          | audit.date          |
-| documentHistory.filter.after  | audit.filter.after  |
-| documentHistory.filter.before | audit.filter.before |
+| Deprecated labels               | New Labels            |
+| ------------------------------- | --------------------- |
+| `documentHistory.category`      | `audit.category`      |
+| `documentHistory.comment`       | `audit.comment`       |
+| `documentHistory.date`          | `audit.date`          |
+| `documentHistory.filter.after`  | `audit.filter.after`  |
+| `documentHistory.filter.before` | `audit.filter.before` |
 
 #### CSS Variables
 
 Deprecated variables should be replaced by the new ones on themes and custom elements making use of them:
 
-- `--nuxeo-document-content-min-height` in favor of `--nuxeo-document-content-height` (affects `nuxeo-document-content`).
-- `--nuxeo-document-trash-content-min-height` in favor of `--nuxeo-document-trash-content-height` (affects `nuxeo-document-trash-content`).
-- `--nuxeo-document-creation-form-icon-width` and `--nuxeo-document-creation-form-icon-height` in favor of the mixin `--nuxeo-document-create-selection-icon` (affects `nuxeo-document-create`).
-- `--nuxeo-document-creation-form-icon-width` and `--nuxeo-document-creation-form-icon-height` in favor of the `--nuxeo-document-create-selection-icon` (see [NXP-27037](https://jira.nuxeo.com/browse/NXP-27037)).
+- `--nuxeo-document-content-min-height`
+  - in favor of `--nuxeo-document-content-height` (affects `nuxeo-document-content`).
+- `--nuxeo-document-trash-content-min-height`
+  - in favor of `--nuxeo-document-trash-content-height` (affects `nuxeo-document-trash-content`).
+- `--nuxeo-document-creation-form-icon-width` and `--nuxeo-document-creation-form-icon-height`
+  - in favor of the mixin `--nuxeo-document-create-selection-icon` (affects `nuxeo-document-create`).
+- `--nuxeo-document-creation-form-icon-width` and `--nuxeo-document-creation-form-icon-height`
+  - in favor of the `--nuxeo-document-create-selection-icon` (see [NXP-27037](https://jira.nuxeo.com/browse/NXP-27037)).
 
 Additionally, the variable `--nuxeo-results-view-min-height` (added in 11.1 [NXP-27652](https://jira.nuxeo.com/browse/NXP-27652)) was removed and can now be safely deleted from your themes or elements.
 


### PR DESCRIPTION
Brings release notes for Web UI from 3.0.0 to 3.0.6 and sets up the hierarchy for future ones
Content can be reviewed but references some pages around the bulk actions documentation that do not exist yet and will be created with NXDOC-2333