### PR TITLE
NXDOC-2533: update web ui vpat for 3.0.18

### DIFF
--- a/assets/nxdoc/master/web-ui-accessibility/2023-01-nuxeo-web-ui-3-0-18-vpat.pdf
+++ b/assets/nxdoc/master/web-ui-accessibility/2023-01-nuxeo-web-ui-3-0-18-vpat.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620e71ab0b64ccbbcf34d88b7758359405362daa9e36888d53cdfac6ca451bd4
+size 848780

--- a/assets/nxdoc/master/web-ui-overview/2022-09-nuxeo-web-ui-lts-2021-3-0-15-VPAT.pdf
+++ b/assets/nxdoc/master/web-ui-overview/2022-09-nuxeo-web-ui-lts-2021-3-0-15-VPAT.pdf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4c11cfe89b47c4b4a459d504da8f5902835239308b6ba95858905c228a4830b
-size 644689

--- a/src/nxdoc/web-ui/web-ui-accessibility.md
+++ b/src/nxdoc/web-ui/web-ui-accessibility.md
@@ -12,8 +12,8 @@ tree_item_index: 600
 
 Nuxeo is committed to making Web UI accessible and keeping a high level of quality on that front. Our target is the WCAG 2.1 standard level AA. Our current level of support for accessibility is controlled regularly, and we publish the results using the standard section 508 Compliance (VPAT) document. Its latest iteration can be found below.
 
-- **Date**: September, 2022
+- **Date**: January, 2023
 - **Product**: Nuxeo Web UI
-- **Link**: [Voluntary Product Accessibility Template for Web UI]({{file name='2022-09-nuxeo-web-ui-lts-2021-3-0-15-VPAT.pdf'}}).
+- **Link**: [Voluntary Product Accessibility Template for Web UI]({{file name='2023-01-nuxeo-web-ui-3-0-18-vpat.pdf'}}).
 
 Updates regarding accessibility improvements in a particular release can be found in the [Web UI release notes]({{page space='nxdoc' page='web-ui-release-notes'}})


### PR DESCRIPTION
Web UI 3.0.18 is publicly available, this PR can be merged anytime
Needs to be backported to LTS 2021.