### PR TITLE
NXDOC-2536: release notes for web ui 3.0.19

### DIFF
--- a/src/nxdoc/web-ui/web-ui-release-notes.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes.md
@@ -3,7 +3,7 @@ title: Web UI Release Notes
 description: Discover changes brought in our recent Nuxeo Web UI updates.
 review:
     comment: ''
-    date: '2023-01-10'
+    date: '2023-02-10'
     status: ok
 toc: true
 labels:
@@ -18,16 +18,17 @@ This page mentions what's new. Refer to the [upgrade notes]({{page page='web-ui-
 
 ## Recently Released Changes
 
-{{{multiexcerpt 'web-ui-updates' page='web-ui-release-notes-3-0-18'}}}
+{{{multiexcerpt 'web-ui-updates' page='web-ui-release-notes-3-0-19'}}}
 
 ---
 
 ## Previous Release Notes
 
-<!-- | [Web UI 3.0.18]({{page page='web-ui-release-notes-3-0-18'}})             | Differentiate views from downloads in the activity and audit (beta). | -->
+<!-- | [Web UI 3.0.19]({{page page='web-ui-release-notes-3-0-19'}})             | Differentiate views from downloads in the activity and audit (general availability). | -->
 
 | Version                                                                       | Summary                                                                    |
 | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [Web UI 3.0.18]({{page page='web-ui-release-notes-3-0-18'}})                  | Differentiate views from downloads in the activity and audit (beta).       |
 | [Web UI 3.0.17]({{page page='web-ui-release-notes-3-0-17'}})                  | Accessibility improvements around contrast and screen reader usage         |
 | [Web UI 3.0.16]({{page page='web-ui-release-notes-3-0-16'}})                  | Accessibility improvements around name, role, value                        |
 | [Web UI 3.0.15]({{page page='web-ui-release-notes-3-0-15'}})                  | Bulk actions - unselect some, accessibility improvements                   |

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-18.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-18.md
@@ -8,7 +8,7 @@ review:
 toc: true
 labels:
 tree_item_index: 986
-hidden: true
+hidden: false
 ---
 
 {{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}
@@ -22,6 +22,7 @@ This release helps differentiating views from downloads in the activity and audi
 
 The audit and activity better reflect actions done in Web UI.
 
+{{! multiexcerpt name='view-vs-download'}}
 When visiting a document, the activity tab shows this action as a view. Activities are registered as a download only when clicking on a download button.
 
 {{!--     ### nx_asset ###
@@ -43,6 +44,7 @@ In the history tab and in the audit, views are distinguished by a specific comme
 {{#> callout type='info' heading='Beta feature'}}
 This feature is in beta state and works on a limited scope at this stage. Images and videos are supported (independently from the document type being used). Support for other file types will come in a future update.
 {{/callout}}
+{{! /multiexcerpt}}
 
 
 ### Other Noteworthy Changes

--- a/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-19.md
+++ b/src/nxdoc/web-ui/web-ui-release-notes/web-ui-release-notes-3-0-19.md
@@ -1,0 +1,42 @@
+---
+title: Version 3.0.19
+description: Discover what's new in Web UI 3.0.19.
+review:
+    comment: ''
+    date: '2023-02-10'
+    status: ok
+toc: true
+labels:
+tree_item_index: 985
+hidden: true
+---
+
+{{{multiexcerpt 'matching-notes' page='web-ui-release-notes'}}}
+
+{{! multiexcerpt name='web-ui-updates'}}
+## What’s New in Web UI for LTS 2021 (Version 3.0.19)
+
+This release helps differentiating views from downloads in the activity and audit.
+
+### Differentiate Views from Downloads (General Availability)
+
+The audit and activity better reflect actions done in Web UI. This feature is now generally available and works with all supported file types.
+
+{{{multiexcerpt 'view-vs-download' page='web-ui-release-notes-3-0-18'}}}
+
+
+### Other Noteworthy Changes
+
+- Search aggregates are updated after applying a new filter.<br/>[[ELEMENTS-1575](https://jira.nuxeo.com/browse/ELEMENTS-1575)]
+- Spreadsheet editor handles Document fields.<br/>[[WEBUI-1031](https://jira.nuxeo.com/browse/WEBUI-1031)]
+- The blob update does not trigger a download any more.<br/>[[ELEMENTS-1534](https://jira.nuxeo.com/browse/ELEMENTS-1534)]
+- The popup disappears when pushing the Cancel button, even with special configurations.<br/>[[WEBUI-1030](https://jira.nuxeo.com/browse/WEBUI-1030)]
+- nuxeo-directory-suggestion for a boolean value works with saved searches.<br/>[[ELEMENTS-1568](https://jira.nuxeo.com/browse/ELEMENTS-1568)]
+
+## Learn More
+
+[More information about released changes and fixed bugs](https://jira.nuxeo.com/issues/?jql=project IN %28%27WEBUI%27%2C %27ELEMENTS%27%29 AND fixVersion IN %28%273.0.19%27%29 ORDER BY 'Epic Link' ASC%2C type DESC%2C  'Backlog priority' DESC%2C component DESC%2C priority DESC) is available in our bug tracking tool.
+
+
+
+{{! /multiexcerpt}}


### PR DESCRIPTION
Release generally available on Feb. 13
This needs to be backported to the LTS 2021 branch.