### PR TITLE
NXDOC-2541: update default value for socketTimeout

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
@@ -1720,7 +1720,7 @@ A maximum period, in milliseconds, of inactivity between two consecutive data pa
 
 **Default Value**
 
-`20000`
+`121000`
 
 * * *
 


### PR DESCRIPTION
elasticsearch.restClient.socketTimeoutMs => 121000