### PR TITLE
NXDOC-2575: how to clean up content

### DIFF
--- a/src/nxdoc/nuxeo-server/administration.md
+++ b/src/nxdoc/nuxeo-server/administration.md
@@ -58,6 +58,7 @@ history:
 
 - [Setup Best Practices]({{page version='' space='nxdoc' page='setup-best-practices'}})
 - [How to Change Context Path]({{page version='' space='nxdoc' page='how-to-change-context-path'}})
+- [How to Clean Up Content]({{page version='' space='nxdoc' page='how-to-clean-up-content'}})
   {{/panel}}
   </div>
 

--- a/src/nxdoc/nuxeo-server/administration/how-to-clean-up-content.md
+++ b/src/nxdoc/nuxeo-server/administration/how-to-clean-up-content.md
@@ -1,0 +1,75 @@
+---
+title: 'HOWTO: Clean Up Content'
+review:
+    comment: ''
+    date: '2023-06-29'
+    status: ok
+details:
+    howto:
+        excerpt: 'Explains what options are available to clean up your orphaned content, which one(s) you should pick based on your situation and how to apply them.'
+        level: Intermediate
+        tool: ''
+        topics: 'garbage collector, log purge, orphaned binaries, cleanup'
+labels:
+    - howto
+tree_item_index: 2250
+---
+
+{{! excerpt}}
+This documentation explains what options are available to clean up your orphaned content, which one(s) you should pick based on your situation and how to apply them.
+{{! /excerpt}}
+
+## How Nuxeo Cleans Up Content
+
+Nuxeo Server is designed to give your complete control over your content and how you dispose of it. 
+
+For example, you may need to keep logs to prove compliance even if the document was deleted, or you may want to keep completed workflows around in order to build analytics and gather insights. To cover for such use cases, Nuxeo Server offers specific ways to dispose of orphaned content, and you need to leverage them explicitly.
+
+Read on to discover what options are available to you, when, how and why you should leverage them.
+
+## Available Options
+
+### Cleaning Up Orphaned Versions for Deleted Documents
+
+When [deleting permanently]({{page page='content-delete' space='userdoc'}}) a document, only the latest copy of the document gets deleted. Previous versions that were created for it are kept in the system, as you may still reference them in other documents, for example in a custom property of a separate document.
+
+If you are confident that older versions of deleted documents are not in use anymore, Nuxeo Server offers a [dedicated REST API endpoint](https://doc.nuxeo.com/rest-api/1/versions-endpoint/#garbage-collect-orphaned-versions) to remove them. 
+
+This endpoint leverages a [bulk action]({{page page='bulk-action-framework'}}), meaning that it is scalable for any repository size and can be easily monitored, even in a context where it could end up being a long-running action.
+
+{{#> callout type='tip'}}
+To get the maximum benefit from your cleanup, it is recommended to leverage this option before cleaning up orphaned binaries, as it may produce new orphaned files.
+{{/callout}}
+
+### Cleaning Up Orphaned Binaries
+
+Nuxeo Server deduplicates content in order to optimize storage costs. This means that multiple documents may reference the same file, and yet it will be stored only once.
+
+When [deleting permanently]({{page page='content-delete' space='userdoc'}}) a document, other documents may still reference some or all of the files it holds. If not, then these files are considered orphaned. 
+
+If you started using Nuxeo after LTS 2021 HF35, orphaned files are cleaned up automatically through a background task. If you chose to disable this feature, an on demand option exists as well.
+
+If you started using Nuxeo before LTS 2021 HF35, then you may need to run some migration steps to gain access to this feature. This will prevent new orphaned files to be created. Existing orphaned files can be cleaned up using the on demand cleanup option.
+
+You can learn how to use this option in the [Garbage Collecting Orphaned Blobs]({{page page='garbage-collecting-orphaned-blobs'}}) documentation.
+
+### Cleaning Up Completed Workflows
+
+Workflows are stored as documents in Nuxeo Server. Each time a workflow is started, new documents are created for each step in the workflow. This means that if you leverage workflows heavily, your document count will grow along.
+ 
+To mitigate this, workflows in state "done" or "canceled" are deleted automatically on a daily basis along with all the steps they contained. And since LTS 2021 HF35, this automatic removal uses a [bulk action]({{page page='bulk-action-framework'}}) to make it even more scalable. 
+
+In addition to this mechanism, it is possible to do further cleanup with the following actions:
+
+By setting the `nuxeo.routing.cleanup.workflow.instances.orphan` [nuxeo.conf property]({{page page='configuration-parameters-index-nuxeoconf'}}) to `true` (`false` by default), the `DocumentRoutingWorkflowInstancesCleanup` listener will also remove orphan workflows daily.
+
+A new management rest API endpoint is also available to perform a workflow garbage collection on demand. See the [workflows endpoint documentation](https://doc.nuxeo.com/rest-api/1/workflows-endpoint). Reasons to use it include:
+- You disabled the automatic workflow cleanup using configuration in order to build reports or gather data on your workflows
+- You did not enable the `nuxeo.routing.cleanup.workflow.instances.orphan` [nuxeo.conf property]({{page page='configuration-parameters-index-nuxeoconf'}}) yet
+- Before LTS 2021 HF35, workflows were not cleaned up in some [specific scenarios](https://jira.nuxeo.com/browse/NXP-31659)
+
+### Cleaning Up Audit Logs
+
+Audit logs keep track of all the activity for documents handled in Nuxeo Server. You may need it for security audits or to prove compliance for example. Therefore, it is kept forever until you explicitly choose to delete it, even for deleted documents. 
+
+You can learn how to use this option in our dedicated [Purging Audit Logs]({{page page='purging-audit-logs-nxp_logs'}}) documentation.

--- a/src/nxdoc/nuxeo-server/administration/how-to-clean-up-content.md
+++ b/src/nxdoc/nuxeo-server/administration/how-to-clean-up-content.md
@@ -21,7 +21,7 @@ This documentation explains what options are available to clean up your orphaned
 
 ## How Nuxeo Cleans Up Content
 
-Nuxeo Server is designed to give your complete control over your content and how you dispose of it. 
+Nuxeo Server is designed to give you complete control over your content and how you dispose of it. 
 
 For example, you may need to keep logs to prove compliance even if the document was deleted, or you may want to keep completed workflows around in order to build analytics and gather insights. To cover for such use cases, Nuxeo Server offers specific ways to dispose of orphaned content, and you need to leverage them explicitly.
 

--- a/src/nxdoc/nuxeo-server/administration/maintenance.md
+++ b/src/nxdoc/nuxeo-server/administration/maintenance.md
@@ -184,11 +184,11 @@ Depending on usage, the audit storage can grow very quickly, discover how to pur
 
 <div class="column medium-6">
 {{#> panel type='secondary' match_height='true'}}
-### Garbage-Collecting Orphaned Binaries
+### Cleaning Up Orphaned Content
 
-Binaries attached to documents are stored using a specialized binary store, learn how to handle them.
+Nuxeo Server offers multiple options to clean up orphaned content to facilitate work at scale and optimize costs.
 
-[More&nbsp;<i class="fa fa-long-arrow-right" aria-hidden="true"></i>]({{page page='garbage-collecting-orphaned-binaries'}})
+[More&nbsp;<i class="fa fa-long-arrow-right" aria-hidden="true"></i>]({{page page='how-to-clean-up-content'}})
 {{/panel}}
 </div>
 


### PR DESCRIPTION
Goal is to cover:
* how content is cleaned up
* what options are available
* what they require
* how / when they should be used 
* to what effect

Options to cover:
* Orphan versions cleanup => https://doc.nuxeo.com/rest-api/1/versions-endpoint/#garbage-collect-orphaned-versions 
* Completed workflows cleanup
* Orphan binaries cleanup => https://doc.nuxeo.com/nxdoc/garbage-collecting-orphaned-blobs/
* Audit log purge => https://doc.nuxeo.com/nxdoc/purging-audit-logs-nxp_logs/ 

Expected outcome:
* Customers understand what options are available to them
* Customers can ask the cloud team to leverage a particular option for their need
* Cloud team is able to understand which options are available and what is best suited for a particular customer
* Customers and cloud team can leverage the available options using the actionable steps described in the doc