### PR TITLE
Update rest-api-web-adapters.md

### DIFF
--- a/src/nxdoc/nuxeo-server/rest-api/rest-api-web-adapters.md
+++ b/src/nxdoc/nuxeo-server/rest-api/rest-api-web-adapters.md
@@ -165,13 +165,13 @@ Default adapters provided by default.
 <table class="hover">
   <tr>
     <td class="small-2">**@annotation**</td>
-    <td>Returns annotations corresponding to the target Document and file:content blob</td>
+    <td>Returns annotations corresponding to the target Document and specific blob property</td>
   </tr>
   <tr>
     <td></td>
     <td>
       ```
-      /api/v1/id/{docId}/@annotation
+      /api/v1/id/{docId}/@annotation?xpath=file:content
       ```
     </td>
   </tr>


### PR DESCRIPTION
the xpath param is required for the `@annotation` adapter, it doesn't default to file:content.  Also it's best to include that in the example to indicate that you can specify any other blob 