### PR TITLE
Fix dubious ownership in repository error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:14
 WORKDIR /node-web-app
+RUN git config --global --add safe.directory /node-web-app
 ENTRYPOINT [ "npm", "run" ]
 CMD [ "dev" ]


### PR DESCRIPTION
Fix errors when trying to build such as:

Command failed: git remote get-url --push origin
fatal: detected dubious ownership in repository at '/node-web-app' To add an exception for this directory, call:

	git config --global --add safe.directory /node-web-app