### PR TITLE
Update nuxeo-studio-community-cookbook.md

### DIFF
--- a/src/studio/nuxeo-studio/nuxeo-studio-community-cookbook.md
+++ b/src/studio/nuxeo-studio/nuxeo-studio-community-cookbook.md
@@ -282,7 +282,8 @@ Feel free to submit your own contribution, following our [guidelines and templat
   <td>
   ![dashboard-cookbook.png](/nx_assets/470c956e-ef24-42d2-b768-938e00bbaa2c.png ?w=150,border=true)
   </td>
-  <td>[Visual Dashboard with Pictures](https://github.com/nuxeo/nuxeo-studio-community-cookbook/blob/master/modules/nuxeo/dashboard)</br> :warning: **DEPRECATED** :warning:</td>
+  <td>[Visual Dashboard with Pictures](https://github.com/nuxeo/nuxeo-studio-community-cookbook/blob/master/modules/nuxeo/dashboard)
+  </td>
   <td>Nuxeo</td>
   <td>Dashboard</td>
 </tr>


### PR DESCRIPTION
Thye DAM dashboard is not deprecated, it was moved to an External template (README updated)