### PR TITLE
NXDOC-3006: Document CDN signed URLs for Nuxeo Media Manipulation (LTS 2025)

### DIFF
--- a/src/nxdoc/nuxeo-add-ons/CDN-signed-URLs-details.md
+++ b/src/nxdoc/nuxeo-add-ons/CDN-signed-URLs-details.md
@@ -24,7 +24,7 @@ Before enabling CDN signed URL sharing, ensure that the following criteria are m
 - **[Amazon S3 Online Storage]({{page page='amazon-s3-online-storage'}})** — binaries stored in S3 via `S3BlobProvider`
 - **[Amazon CloudFront]({{page page='amazon-cloudfront-distribution'}})** — distribution in front of the S3 bucket, with **Restrict Viewer Access** enabled so objects require signed URLs
 - **CloudFront signing key** — Key Pair ID and private key file mounted on every Nuxeo node
-- **Nuxeo Media Manipulation** add-on installed
+- **Nuxeo Media Manipulation** add-on is installed
 
 Picture view generations for **OriginalJpeg** and **FullHD** must be enabled if you intend to share those renditions.
 

--- a/src/nxdoc/nuxeo-add-ons/CDN-signed-URLs-details.md
+++ b/src/nxdoc/nuxeo-add-ons/CDN-signed-URLs-details.md
@@ -18,7 +18,7 @@ This page covers prerequisites and `nuxeo.conf` configuration. For the end-user 
 
 ## Prerequisites
 
-Before enabling CDN signed URL sharing:
+Before enabling CDN signed URL sharing, ensure that the following criteria are met:
 
 - **Nuxeo Platform** — LTS 2025 (or the platform version supported by your Media Manipulation package)
 - **[Amazon S3 Online Storage]({{page page='amazon-s3-online-storage'}})** — binaries stored in S3 via `S3BlobProvider`
@@ -36,7 +36,7 @@ When S3 and CloudFront are configured, users generate CDN signed URLs from the *
 2. Click **Create CDN URL**.
 3. Copy the generated URL.
 
-Nuxeo signs the URL; subsequent downloads are served by CloudFront, not by Nuxeo. Optional date fields in the Share card control **document permissions** in Nuxeo; **URL validity** is governed solely by the CloudFront signature expiration.
+Nuxeo signs the URL. Subsequent downloads are served by CloudFront, not by Nuxeo. Optional date fields in the Share card control **document permissions** in Nuxeo; **URL validity** is governed solely by the CloudFront signature expiration.
 
 **Important:** CDN signed URLs apply to **stored blobs only**. On-the-fly crop, resize, or format changes from the manipulation dialog are not included. Use **Download as** or **Save** to persist a transformation first, then share the resulting blob if needed.
 

--- a/src/nxdoc/nuxeo-add-ons/CDN-signed-URLs-details.md
+++ b/src/nxdoc/nuxeo-add-ons/CDN-signed-URLs-details.md
@@ -1,0 +1,141 @@
+---
+title: CDN Signed URLs Details
+description: Configuration and behavior of CDN signed URL sharing for Nuxeo Media Manipulation.
+review:
+  comment: ''
+  date: '2026-08-24'
+  status: ok
+labels:
+  - lts2025-ok
+  - media-manipulation
+  - dam
+toc: true
+---
+
+CDN signed URLs let users share **stored blobs** (main file and existing picture views such as OriginalJPEG and FullHD) through Amazon CloudFront without routing downloads through the Nuxeo server. URLs are signed and time-limited; end users access content directly from CloudFront edge locations.
+
+This page covers prerequisites and `nuxeo.conf` configuration. For the end-user workflow (**Share → Create CDN URL**), see [Nuxeo Media Manipulation]({{page page='nuxeo-media-manipulation'}}#sharing).
+
+## Prerequisites
+
+Before enabling CDN signed URL sharing:
+
+- **Nuxeo Platform** — LTS 2025 (or the platform version supported by your Media Manipulation package)
+- **[Amazon S3 Online Storage]({{page page='amazon-s3-online-storage'}})** — binaries stored in S3 via `S3BlobProvider`
+- **[Amazon CloudFront]({{page page='amazon-cloudfront-distribution'}})** — distribution in front of the S3 bucket, with **Restrict Viewer Access** enabled so objects require signed URLs
+- **CloudFront signing key** — Key Pair ID and private key file mounted on every Nuxeo node
+- **Nuxeo Media Manipulation** add-on installed
+
+Picture view generations for **OriginalJpeg** and **FullHD** must be enabled if you intend to share those renditions.
+
+## Overview
+
+When S3 and CloudFront are configured, users generate CDN signed URLs from the **Share** card in the Media Manipulation dialog:
+
+1. Select the blob to share from **Select a Value** (main file or an existing picture view).
+2. Click **Create CDN URL**.
+3. Copy the generated URL.
+
+Nuxeo signs the URL; subsequent downloads are served by CloudFront, not by Nuxeo. Optional date fields in the Share card control **document permissions** in Nuxeo; **URL validity** is governed solely by the CloudFront signature expiration.
+
+**Important:** CDN signed URLs apply to **stored blobs only**. On-the-fly crop, resize, or format changes from the manipulation dialog are not included. Use **Download as** or **Save** to persist a transformation first, then share the resulting blob if needed.
+
+## Nuxeo Configuration
+
+Add the following to `nuxeo.conf`:
+
+```properties
+# S3 binary storage (required)
+nuxeo.core.binarymanager=org.nuxeo.ecm.blob.s3.S3BlobProvider
+nuxeo.s3storage.bucket=<your-bucket-name>
+
+# CloudFront signing (required for CDN delivery)
+nuxeo.s3storage.cloudfront.enabled=true
+nuxeo.s3storage.cloudfront.distribDomain=<your-cloudfront-domain>
+nuxeo.s3storage.cloudfront.distribId=<cloudfront-distribution-id>
+nuxeo.s3storage.cloudfront.privKey=/etc/nuxeo/cloudfront/pk-<Key-Pair-Id>.pem
+nuxeo.s3storage.cloudfront.privKeyId=<Key-Pair-Id>
+nuxeo.s3storage.cloudfront.bucket.prefix=binaries
+
+# Media Manipulation — enable CDN URL sharing in the Share card
+nuxeo.media.downloadlinks.cloudfront.enabled=true
+
+# Signed URL lifetime (default: 3600 seconds / 1 hour)
+nuxeo.s3storage.cloudfront.expiration.seconds=3600
+```
+
+Restart Nuxeo after changing these properties. Mount the private key file at the same path on **all** Nuxeo nodes in the cluster.
+
+You do not need `nuxeo.aws.accessKeyId` and `nuxeo.aws.secretKey` when using IAM instance roles for S3 access.
+
+### Configuration reference
+
+| Property | Description |
+| -------- | ----------- |
+| `nuxeo.s3storage.cloudfront.enabled` | Enables CloudFront signed URL generation at the S3 storage layer. |
+| `nuxeo.media.downloadlinks.cloudfront.enabled` | Enables **Create CDN URL** in the Media Manipulation Share card. |
+| `nuxeo.s3storage.cloudfront.distribDomain` | CloudFront distribution domain (for example `d111111abcdef8.cloudfront.net`). |
+| `nuxeo.s3storage.cloudfront.distribId` | CloudFront distribution ID. |
+| `nuxeo.s3storage.cloudfront.privKey` | Filesystem path to the CloudFront private key (`.pem`). |
+| `nuxeo.s3storage.cloudfront.privKeyId` | CloudFront Key Pair ID (`K...` for Key Groups, `APK...` for Trusted Signers). |
+| `nuxeo.s3storage.cloudfront.bucket.prefix` | S3 key prefix where binaries are stored (default: `binaries`). |
+| `nuxeo.s3storage.cloudfront.expiration.seconds` | Signed URL validity in seconds (default: `3600`). |
+
+## CloudFront Signing — Key Groups and Trusted Signers
+
+Nuxeo supports both modern and legacy AWS CloudFront signing setups:
+
+| Signing approach | Key-Pair-Id format | Private key format | PEM header |
+| ---------------- | ------------------ | ------------------ | ---------- |
+| Key Groups (modern) | `K...` | PKCS#8 | `-----BEGIN PRIVATE KEY-----` |
+| Trusted Signers (legacy) | `APK...` | PKCS#1 | `-----BEGIN RSA PRIVATE KEY-----` |
+
+Store the private key at the path configured in `nuxeo.s3storage.cloudfront.privKey` (for example `/etc/nuxeo/cloudfront/pk-<Key-Pair-Id>.pem`).
+
+For CloudFront distribution settings (Restrict Bucket Access, Query String Forwarding, Restrict Viewer Access), follow [Amazon CloudFront]({{page page='amazon-cloudfront-distribution'}}).
+
+## Lambda@Edge Migration
+
+When `nuxeo.s3storage.cloudfront.privKey` and `nuxeo.s3storage.cloudfront.privKeyId` are configured, Nuxeo signs CloudFront URLs directly. Customers who previously used **Lambda@Edge** for URL signing can remove it after validating Nuxeo-generated signed URLs in production:
+
+1. Configure `nuxeo.conf` as above and confirm signed URLs return `200 OK`.
+2. Remove the Lambda@Edge association from the CloudFront distribution once Nuxeo signing is confirmed.
+
+## Link Lifetime
+
+Signed URL expiration defaults to **3600 seconds (1 hour)** via `nuxeo.s3storage.cloudfront.expiration.seconds`. Increase this value to extend link validity (for example `7200` for two hours).
+
+Revocation before expiration is **not supported** from the UI or via API. A signed URL remains valid until its CloudFront signature expires.
+
+## Known Limitations
+
+- CDN signed URLs are limited to **stored blobs** (main file and picture views); on-the-fly transformations cannot be shared via CDN URL.
+- Signed URLs **cannot be revoked** before their CloudFront signature expires.
+- **New** CDN signed URLs cannot be generated while Nuxeo is unavailable (signing happens on the server).
+- Links **already issued** can continue to work until they expire, even if Nuxeo is temporarily down.
+- Not intended for permanent public URLs or CDN-based on-the-fly image transformation (see [Future Scope]({{page page='nuxeo-media-manipulation'}}#future-scope) on the main page).
+- Requires S3-backed blob storage and a CloudFront distribution configured for signed access.
+
+When the underlying blob changes, create a **new** CDN URL so consumers access the updated content.
+
+## Frequently Asked Questions
+
+**Does the CDN signed URL replace the original asset in Nuxeo?**
+
+No. Nuxeo remains the system of record. The feature changes how a stored blob is delivered publicly, not where it is managed.
+
+**How long does a CDN signed URL remain valid?**
+
+By default, about one hour. Configure `nuxeo.s3storage.cloudfront.expiration.seconds` to change the duration.
+
+**Can I revoke a CDN signed URL before it expires?**
+
+No. If you need stronger revocation control, use Nuxeo's classic authenticated download or public link models instead.
+
+**What happens if the file is updated?**
+
+Create a new CDN URL for the updated blob. Existing signed URLs continue to serve the version that was stored when the URL was generated, until they expire.
+
+**Will CDN signed URLs work if Nuxeo is down?**
+
+Already-created links can keep working until they expire. New URLs cannot be generated while Nuxeo is unavailable.

--- a/src/nxdoc/nuxeo-add-ons/nuxeo-media-manipulation.md
+++ b/src/nxdoc/nuxeo-add-ons/nuxeo-media-manipulation.md
@@ -26,7 +26,7 @@ Customers can install this just like any other add-on onto the nuxeo server inst
 ## Prerequisites
 Nuxeo Platform – LTS-2025 
 
-Nuxeo Web UI – dependent package which will be installed if not present. 
+Nuxeo Web UI – dependent package must be installed if not present. 
 
 Picture View generations for OriginalJpeg and FullHD are enabled. 
 
@@ -93,7 +93,7 @@ CDN signed URLs can be generated for stored blobs (main file and existing pictur
 
 In the Share card, select the blob to share from **Select a Value**, then click **Create CDN URL**. Copy the generated URL using the copy action.
 
-The URL remains valid until its CloudFront signature expires. Expiration is controlled by `nuxeo.s3storage.cloudfront.expiration.seconds` (default: 3600 seconds). Revocation is not available from the UI; a signed URL stays valid until it expires.
+The URL remains valid until its CloudFront signature expires. Expiration is controlled by `nuxeo.s3storage.cloudfront.expiration.seconds` (default: 3600 seconds). Revocation is not available from the UI. A signed URL stays valid until it expires.
 
 **Note:** CDN signed URLs serve stored blobs only. On-the-fly crop, resize, or format changes from the manipulation dialog are not included in the CDN URL. Use **Download as** or **Save** to persist a transformation first, then share the resulting blob if needed.
 
@@ -154,7 +154,7 @@ Possible timeouts during the transformation of large sized images.
 The transaction timeout needs to be increased explicitly in such cases using the config key: 
 `nuxeo.media.transform.transaction.timeout.seconds`
 
-CDN signed URLs are limited to stored blobs (main file and picture views); on-the-fly transformations cannot be shared via CDN URL.
+CDN signed URLs are limited to stored blobs (main file and picture views). On-the-fly transformations cannot be shared via CDN URL.
 
 CDN signed URLs cannot be revoked before their CloudFront signature expires.
 

--- a/src/nxdoc/nuxeo-add-ons/nuxeo-media-manipulation.md
+++ b/src/nxdoc/nuxeo-add-ons/nuxeo-media-manipulation.md
@@ -3,7 +3,7 @@ title: Nuxeo Media Manipulation
 description: 'Nuxeo Media Manipulation documentation'
 review:
     comment: ''
-    date: '2025-06-11'
+    date: '2026-08-24'
     status: ok
 labels:
     - lts2025-ok
@@ -24,16 +24,18 @@ The connector is available as a single add-on package in nuxeo marketplace.
 Customers can install this just like any other add-on onto the nuxeo server instance. 
 
 ## Prerequisites
-Nuxeo Platform – LTS-2023 
+Nuxeo Platform – LTS-2025 
 
 Nuxeo Web UI – dependent package which will be installed if not present. 
 
 Picture View generations for OriginalJpeg and FullHD are enabled. 
 
+Nuxeo S3 Binary Storage with CloudFront configured. CDN signed URL sharing must be enabled (`nuxeo.media.downloadlinks.cloudfront.enabled=true`). See [CDN signed URLs details]({{page page='CDN-signed-URLs-details'}}).
+
 ## Current Scope
 Supported Media Facets: Picture 
 
-Supported Functionalities: Cropping and Resizing, Addition of custom aspect ratio options, Output format selection, Download, Share – Public link, Save Manipulation as rendition, Save Manipulation as Derivative document. 
+Supported Functionalities: Cropping and Resizing, Addition of custom aspect ratio options, Output format selection, Download, Share – CDN signed URL, Save Manipulation as rendition, Save Manipulation as Derivative document. 
 
 ## Functional Overview
 After installation of the package, on a given picture faceted document, for the users that have write permission, a document action - Edit Media - is enabled. 
@@ -60,6 +62,10 @@ All the transformations done on the FullHD view will be scaled accordingly and a
 
 The threshold at which this should happen is configurable and this would happen when the size of the originalJPEG rendition in MB > nuxeo.media.image.maxsize. 
 
+When S3 binary storage and CloudFront are configured, users can generate CDN signed URLs from the Share card to deliver stored blobs without authentication. URLs point to content served through CloudFront rather than through the Nuxeo server. Optional date fields in the Share card control document permissions; URL validity is governed by the CloudFront signature expiration.
+
+For configuration details, see [CDN signed URLs details]({{page page='CDN-signed-URLs-details'}}).
+
 ### Cropping, Resizing and Aspect Ratios
 
 The crop panel displays the picture and the crop box. Crop box can be operated freely when the Aspect ratio is selected as free, which is default. 
@@ -83,11 +89,13 @@ As these options sourced to the vocabulary: aspectRatio, admin can configure the
 
 ### Sharing
 
-Public URLs can be generated for the desired/existing transformation(s). These URLs won't need any authentication and can be simply used to get the transformed image. 
- 
-To generate URL for desired/current transformation, the option of Custom must be selected in the drop down – Select a Value and clicking on create public url button. 
- 
-The generated URL can be timeboxed by selecting from and to dates. 
+CDN signed URLs can be generated for stored blobs (main file and existing picture views such as OriginalJPEG and FullHD). These URLs do not require authentication and deliver content directly through CloudFront.
+
+In the Share card, select the blob to share from **Select a Value**, then click **Create CDN URL**. Copy the generated URL using the copy action.
+
+The URL remains valid until its CloudFront signature expires. Expiration is controlled by `nuxeo.s3storage.cloudfront.expiration.seconds` (default: 3600 seconds). Revocation is not available from the UI; a signed URL stays valid until it expires.
+
+**Note:** CDN signed URLs serve stored blobs only. On-the-fly crop, resize, or format changes from the manipulation dialog are not included in the CDN URL. Use **Download as** or **Save** to persist a transformation first, then share the resulting blob if needed.
 
 {{!--     ### nx_asset ###
     path: /default-domain/workspaces/Product Management/Documentation/Documentation Screenshots/NXDOC/Master/Nuxeo Media Manipulation/Share
@@ -105,11 +113,6 @@ Allows to download the image applying the desired transformations in the selecte
     addins#screenshot#up_to_date
 --}}
 ![Download as](/nx_assets/fb6fe2ff-b05b-4d93-8e6b-e9281df34ef1.png ?w=650,border=true)
-
-For both the download and public link use cases, please make sure to add the  
-`nuxeo.url` config key with appropriate nuxeo host value: 
-
-`Eg: nuxeo.url=https://<your domain name here>/nuxeo`
 
 ### Saving
 
@@ -140,7 +143,7 @@ Upon save as derivative, a new document will be created, copying from the curren
 --}}
 ![new rendition](/nx_assets/48265045-06ee-4e1d-87b1-00225811e3a3.png ?w=650,border=true)
 
-A new document can been seen with name: Derivative – City
+A new document can be seen with name: Derivative – City
 
 ## Known Limitations 
 
@@ -151,11 +154,15 @@ Possible timeouts during the transformation of large sized images.
 The transaction timeout needs to be increased explicitly in such cases using the config key: 
 `nuxeo.media.transform.transaction.timeout.seconds`
 
+CDN signed URLs are limited to stored blobs (main file and picture views); on-the-fly transformations cannot be shared via CDN URL.
+
+CDN signed URLs cannot be revoked before their CloudFront signature expires.
+
 ## Future Scope
 
 Support of additional media and functionalities. 
 
 Asynchronous handling of invoked transformation requests with a dashboard to check the status.
 
-Delivery through CDN.
+CDN-based image editing, resizing, or on-the-fly transformation capabilities — beyond the current CDN signed URL delivery for stored blobs.
  


### PR DESCRIPTION
## Summary

- Add `CDN-signed-URLs-details.md` as a configuration reference for CDN signed URL sharing (S3, CloudFront, `nuxeo.conf` properties, signing keys, limitations, and FAQ) for LTS 2025.
- Update `nuxeo-media-manipulation.md` to document CDN signed URL sharing instead of public links: correct LTS-2025 prerequisite, Share card workflow, known limitations, and cross-links to the new details page.

## Test plan

- [ ] Run `npm run dev` and verify `CDN-signed-URLs-details` renders at `/nxdoc/nuxeo-add-ons/CDN-signed-URLs-details`
- [ ] Confirm links from `nuxeo-media-manipulation` Prerequisites and Functional Overview resolve correctly
- [ ] Review Share section and Known Limitations for consistency between both pages
- [ ] Verify table of contents appears on the CDN details page (`toc: true`)


Made with [Cursor](https://cursor.com)