### PR TITLE
NXDOC-2980: Update LTS 2025 pages for MongoDB Atlas and search requirements

### DIFF
--- a/src/nxdoc/nuxeo-server/installation/compatibility-matrix.md
+++ b/src/nxdoc/nuxeo-server/installation/compatibility-matrix.md
@@ -81,7 +81,7 @@ The Nuxeo Platform supports the following databases.
   <li>
     Recommended, validated by continuous integration:
     <ul>
-      <li>{{! multiexcerpt name='MongoDB-supported'}}MongoDB 8{{! /multiexcerpt}}</li>
+      <li>{{! multiexcerpt name='MongoDB-supported'}}MongoDB 8 / MongoDB Atlas{{! /multiexcerpt}}</li>
       <li>{{! multiexcerpt name='PostgreSQL-supported'}}PostgreSQL 16{{! /multiexcerpt}}</li>
     </ul>
   </li>
@@ -158,6 +158,12 @@ nuxeo-audit-elasticsearch9:         OS1 🚫, OS2 🚫, OS3 🚫, ES7 🚫, ES8 
 ```
 
 More information can be found on the [Search setup for OpenSearch 1.x and Elasticsearch 7.x–8.x]({{page page='search-setup-opensearch1'}}) (Elasticsearch 7–8 via `nuxeo-search-client-opensearch1`), [Search setup for Elasticsearch 9.x]({{page page='search-setup-elasticsearch9'}}), and [Search setup]({{page page='search-setup'}}) pages.
+
+## MongoDB Atlas Search
+
+When the repository runs on MongoDB Atlas, Nuxeo Platform can use MongoDB Atlas Search as its search backend instead of an external OpenSearch or Elasticsearch cluster, using the `nuxeo-search-client-mongoatlas` package.
+
+More information can be found on the [MongoDB Atlas Search]({{page page='search-setup-mongoatlas'}}) page.
 
 ## Kafka
 

--- a/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-architecture-components/elasticsearch-architecture.md
+++ b/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-architecture-components/elasticsearch-architecture.md
@@ -23,7 +23,7 @@ A search engine such as Elasticsearch (or OpenSearch)  is used to relieve the da
 - It stores the document's audit log. Since every operation on a document in Nuxeo is stored for possible audit purposes, the corresponding table would grow very rapidly and possibly reach millions of tuples when stored in the database. Using Elasticsearch, this is not a problem anymore.
 - It scales horizontally and provides constant performance even with growing content size.
 
-A search engine is a mandatory component of the Nuxeo architecture: in a development environment, it makes sense to use the embedded OpenSearch package, but a Nuxeo production environment expects an externalized Elasticsearch or OpenSearch cluster. Refer to the [Search setup]({{page page='search-setup'}}) documentation for more information.
+A search engine is not required: Nuxeo can rely on the repository (database) search alone. However, a dedicated search engine is recommended for scalable and performant solutions. When a search engine is used, Nuxeo supports an externalized OpenSearch, Elasticsearch, or MongoDB Atlas Search backend. In a development environment, it makes sense to use the embedded OpenSearch package. Refer to the [Search setup]({{page page='search-setup'}}) documentation for more information.
 
 ## Recommendation
 

--- a/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-reference-architectures/compact-architecture-with-kafka.md
+++ b/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-reference-architectures/compact-architecture-with-kafka.md
@@ -16,9 +16,9 @@ This is a compact architecture because it includes a single Kafka node running i
 In this architecture:
 - A load balancer with sticky sessions is used.
 - A total of two machines are prepared for the application cluster. Each machine holds a Nuxeo server node and a reverse proxy. More machines can be added later for scalability purpose.
-- A search engine cluster (OpenSearch, Elasticsearch, or MongoDB Atlas Search) is highly recommended for scalable and performant search, though Nuxeo can also rely on repository search only
-- A database cluster with at least 2 nodes
-- A **Kafka node** as the default implementation for Nuxeo Stream
+- A search engine cluster (OpenSearch, Elasticsearch, or MongoDB Atlas Search) is highly recommended for scalable and performant search, though Nuxeo can also rely on repository search only.
+- A database cluster with at least 2 nodes.
+- A **Kafka node** as the default implementation for Nuxeo Stream.
 
 {{!--     ### nx_asset ###
     path: /default-domain/workspaces/Product Management/Documentation/Documentation Screenshots/NXDOC/Master/Nuxeo Scalability Options/compact-with-kafka-1.png

--- a/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-reference-architectures/compact-architecture-with-kafka.md
+++ b/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-reference-architectures/compact-architecture-with-kafka.md
@@ -11,12 +11,12 @@ tree_item_index: 200
 
 ## Architecture Description
 
-This is a compact architecture because it includes a single node for Kafka, so you don't need to deploy Zookeeper to keep track of status of the Kafka cluster nodes, Kafka topics, partitions etc.
+This is a compact architecture because it includes a single Kafka node running in standalone mode (KRaft), so there is no separate coordination service to deploy.
 
 In this architecture:
 - A load balancer with sticky sessions is used.
 - A total of two machines are prepared for the application cluster. Each machine holds a Nuxeo server node and a reverse proxy. More machines can be added later for scalability purpose.
-- An Elasticsearch cluster with at least 3 nodes
+- A search engine cluster (OpenSearch, Elasticsearch, or MongoDB Atlas Search) is highly recommended for scalable and performant search, though Nuxeo can also rely on repository search only
 - A database cluster with at least 2 nodes
 - A **Kafka node** as the default implementation for Nuxeo Stream
 


### PR DESCRIPTION
[NXDOC-2980](https://hyland.atlassian.net/browse/NXDOC-2980)

Correct LTS 2025 architecture/compatibility pages:

- **Search Engines**: a search engine is no longer described as mandatory — Nuxeo can rely on repository (database) search alone, while a dedicated engine is recommended for scale/performance. Backends listed: OpenSearch, Elasticsearch, MongoDB Atlas Search.
- **Compact Architecture with Kafka**: drop the Zookeeper mention (single Kafka node runs standalone in KRaft mode); make the search engine cluster optional/recommended.
- **Compatibility Matrix**: add MongoDB Atlas to the databases list; add a dedicated MongoDB Atlas Search backend section (Atlas Search kept out of the CI-validated DB list).

Note: the compact-with-kafka diagram still shows Elasticsearch/Zookeeper and is left unchanged in this PR.