### PR TITLE
NXDOC-3015: Warn to finish migration before restarting in Search Setup

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/search-setup.md
+++ b/src/nxdoc/nuxeo-server/administration/search-setup.md
@@ -3,7 +3,7 @@ title: Search Setup
 description: This page provides several configuration use cases for Elasticsearch and Opensearch.
 review:
     comment: ''
-    date: '2026-04-07'
+    date: '2026-09-02'
     status: ok
 labels:
     - lts2016-ok
@@ -687,6 +687,8 @@ curl -XPOST -u Administrator:Administrator \
     "http://localhost:8080/nuxeo/api/v1/management/search/reindex?index=enhanced-green"
 ```
 
+The response returns a `commandId` that you can use to track progress.
+
 **Step 3: Test the new index**
 
 Verify the new index using the management search endpoint:
@@ -705,6 +707,17 @@ curl -XGET -u Administrator:Administrator \
 ```
 
 **Step 4: Switch to the new index**
+
+{{#> callout type='warning' heading='Finish the migration before restarting'}}
+Do not switch to the green index until the re-indexing launched in Step 2 has completed. Check the bulk command status and wait for its state to be `COMPLETED`:
+
+```shell
+curl -XGET -u Administrator:Administrator \
+  "http://localhost:8080/nuxeo/api/v1/management/bulk/<commandId>"
+```
+
+If you swap the index and perform the rolling restart while the re-indexing is still running, a partially populated green index becomes the index serving all search requests, and documents that have not been indexed yet are missing from search results.
+{{/callout}}
 
 Update `nuxeo.conf` to swap to the new index:
 
@@ -851,6 +864,10 @@ For mapping customization examples, see the page [Configuring the Elasticsearch 
 
 Here the index is a primary storage and you cannot rebuild it. So we need a tool that will extract the `_source` of documents from one index and submit it to a new index that have been setup with the new configuration.
 
+{{#> callout type='warning' heading='Finish the migration before restarting'}}
+The audit index is a primary storage: unlike the repository index, it cannot be rebuilt from the repository. Once you stop the Nuxeo Platform to copy the entries, do not start it again — and do not delete the source index — until the `_reindex` request has completed and both indexes report the same document count. Audit entries that were not copied are lost permanently.
+{{/callout}}
+
 1. Update the mappings or settings configuration by overriding the `{NUXEO_HOME}/templates/opensearch1-audit/nxserver/config/opensearch1-audit-config.xml.nxftl`(follow the same procedure as the section above for the repository index)
 1. Use a new name for the `nuxeo.audit.backend.default.opensearch1.index.name` (like `nuxeo-audit2`)
 1. Start the Nuxeo Platform.</br>
@@ -868,6 +885,36 @@ Here the index is a primary storage and you cannot rebuild it. So we need a tool
     }
     }'
     ```
+
+    On a large audit index, send the request asynchronously and poll the returned task instead of waiting on the call:
+
+    ```bash
+    curl -X POST "http://localhost:9200/_reindex?wait_for_completion=false" \
+      -H 'Content-Type: application/json' -d '{
+    "source": {
+    "index": "nuxeo-audit"
+    },
+    "dest": {
+    "index": "nuxeo-audit2"
+    }
+    }'
+
+    # poll the task id returned by the request above
+    curl "http://localhost:9200/_tasks/<taskId>?pretty"
+    ```
+
+1. Wait for the `_reindex` request to complete, then refresh the new index and check that both indexes hold the same number of entries.
+
+    ```bash
+    curl -X POST "http://localhost:9200/nuxeo-audit2/_refresh"
+
+    curl "http://localhost:9200/nuxeo-audit/_count?pretty"
+    curl "http://localhost:9200/nuxeo-audit2/_count?pretty"
+    ```
+
+    The destination index is not refreshed automatically when `_reindex` finishes, so counts taken straight after the copy can be stale and look mismatched even though every entry was copied.
+
+1. Start the Nuxeo Platform.
 
 ## Configuration for Multi Repositories
 


### PR DESCRIPTION
[NXDOC-3015](https://hyland.atlassian.net/browse/NXDOC-3015)

## Problem

Both migration procedures on the [Search Setup](https://doc.nuxeo.com/nxdoc/search-setup/) page ended with a restart step and no completion gate.

**Blue/green re-indexing** — Step 4 said to swap `nuxeo.search.client.default.*.index.name` to the green index and perform a rolling restart, without first confirming the re-index launched in Step 2 had finished. The section already documents *how* to monitor progress (bulk status API) and how to roll back, but never says not to switch until it reports complete. Restarting early promotes a partially populated green index to serve all search requests.

**Audit index** — `Updating the Audit Logs Index Configuration` told you to stop Nuxeo and issue `_reindex`, then simply ended. No step to wait for it, verify the copy, or restart. That matters more here: the page itself states this index *"is a primary storage and you cannot rebuild it"*, so entries not copied before the platform restarts or the source index is dropped are lost permanently. `_reindex` also returns immediately when run async, and on a large audit index it takes a long time.

## Change

- Warning callout at blue/green Step 4: don't switch until the bulk command reports `COMPLETED`, with the status call and the consequence spelled out.
- Audit procedure: added the missing wait/verify/start steps — poll for completion, compare `_count` on both indexes, then start Nuxeo — plus an async `wait_for_completion=false` + `_tasks` variant for large indexes.
- Warning callout on the audit procedure covering the primary-storage/permanent-loss point.

No behaviour claims beyond what the page already documents; this is sequencing and verification guidance only.

## Notes

- `2025` branch only. The blue/green procedure is LTS 2025.11+, so it doesn't exist on `2023`. The audit `_reindex` procedure does exist there, so the second half may be worth backporting — happy to follow up if wanted.
- Bumped the `review:` date per the convention in recent commits.
- Deps aren't installed locally so I didn't run a metalsmith build. Verified by inspection instead: callout open/close balanced (9/9), code-fence parity even, frontmatter change is a single date value within an existing key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)