### PR TITLE
NXDOC-3015: Warn to finish audit migration before restarting in Search Setup [2023]

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/search-setup.md
+++ b/src/nxdoc/nuxeo-server/administration/search-setup.md
@@ -3,7 +3,7 @@ title: Search Setup
 description: This page provides several configuration use cases for Elasticsearch and Opensearch.
 review:
     comment: ''
-    date: '2020-11-03'
+    date: '2026-09-02'
     status: ok
 labels:
     - lts2016-ok
@@ -855,6 +855,10 @@ For mapping customization examples, see the page [Configuring the Elasticsearch 
 
 Here the index is a primary storage and you cannot rebuild it. So we need a tool that will extract the `_source` of documents from one index and submit it to a new index that have been setup with the new configuration.
 
+{{#> callout type='warning' heading='Finish the migration before restarting'}}
+The audit index is a primary storage: unlike the repository index, it cannot be rebuilt from the repository. Once you stop the Nuxeo Platform to copy the entries, do not start it again — and do not delete the source index — until the `_reindex` request has completed and both indexes report the same document count. Audit entries that were not copied are lost permanently.
+{{/callout}}
+
 1. Update the mappings or settings configuration by overriding the `{NUXEO_HOME}/templates/common-base/nxserver/config/elasticsearch-audit-index-config.xml`(follow the same procedure as the section above for the repository index)
 1. Use a new name for the `audit.elasticsearch.indexName` (like `nuxeo-audit2`)
 1. Start the Nuxeo Platform.</br>
@@ -872,6 +876,36 @@ Here the index is a primary storage and you cannot rebuild it. So we need a tool
     }
     }'
     ```
+
+    On a large audit index, send the request asynchronously and poll the returned task instead of waiting on the call:
+
+    ```bash
+    curl -X POST "http://localhost:9200/_reindex?wait_for_completion=false" \
+      -H 'Content-Type: application/json' -d '{
+    "source": {
+    "index": "nuxeo-audit"
+    },
+    "dest": {
+    "index": "nuxeo-audit2"
+    }
+    }'
+
+    # poll the task id returned by the request above
+    curl "http://localhost:9200/_tasks/<taskId>?pretty"
+    ```
+
+1. Wait for the `_reindex` request to complete, then refresh the new index and check that both indexes hold the same number of entries.
+
+    ```bash
+    curl -X POST "http://localhost:9200/nuxeo-audit2/_refresh"
+
+    curl "http://localhost:9200/nuxeo-audit/_count?pretty"
+    curl "http://localhost:9200/nuxeo-audit2/_count?pretty"
+    ```
+
+    The destination index is not refreshed automatically when `_reindex` finishes, so counts taken straight after the copy can be stale and look mismatched even though every entry was copied.
+
+1. Start the Nuxeo Platform.
 
 ## Configuration for Multi Repositories
 


### PR DESCRIPTION
[NXDOC-3015](https://hyland.atlassian.net/browse/NXDOC-3015) — LTS 2023 backport of the audit half of #2826.

## Problem

`Updating the Audit Logs Index Configuration` on the [Search Setup](https://doc.nuxeo.com/2023/nxdoc/search-setup/) page tells you to stop Nuxeo and issue `_reindex`, and then simply ends. There is no step to wait for it, verify the copy, or restart.

That matters because the same page states this index *"is a primary storage and you cannot rebuild it"* — so audit entries not copied before the platform restarts or the source index is dropped are gone permanently. `_reindex` also returns immediately when run async, and on a large audit index it takes a long time.

The procedure text on this branch is identical to `2025`; only the property names (`audit.elasticsearch.indexName`) and the template path differ, and this change touches neither.

## Change

- Added the missing steps: poll for completion, compare `_count` on both indexes, then start Nuxeo.
- Added an async `wait_for_completion=false` + `_tasks` variant for large indexes.
- Added a warning callout covering the primary-storage / permanent-loss point.

## Scope

The blue/green re-indexing warning from #2826 is **not** backported — that procedure is LTS 2025.11+ and doesn't exist on this branch. This PR is the audit half only.

## Notes

- Bumped the `review:` date per the convention in recent commits (it was still `2020-11-03`).
- Deps aren't installed locally so I didn't run a metalsmith build. Verified by inspection: callout open/close balanced (10/10), code-fence parity even, frontmatter change is a single date value within an existing key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)