### PR TITLE
NXDOC-3014: Document the audit path for search technology migration

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/search-setup.md
+++ b/src/nxdoc/nuxeo-server/administration/search-setup.md
@@ -478,6 +478,8 @@ Pick the guide that matches your search stack (packages, optional embedded serve
 | Elasticsearch 9.x | `elasticsearch9` | `nuxeo-search-client-elasticsearch9` | [Search setup for Elasticsearch 9.x]({{page page='search-setup-elasticsearch9'}}) |
 | MongoDB Atlas Search (repository on MongoDB Atlas) | `mongoatlas` | `nuxeo-search-client-mongoatlas` | [MongoDB Atlas Search]({{page page='search-setup-mongoatlas'}}) |
 
+If you are changing the search technology of an existing instance, see [Migrating Search Technology]({{page page='search-setup-migration'}}) for what has to be migrated and which procedure applies to each part.
+
 Audit and optional embedded packages are listed on each guide where they apply. For a Marketplace-oriented overview, see [Nuxeo Search Client OpenSearch]({{page page='nuxeo-search-client-opensearch'}}), [Nuxeo Search Client Elasticsearch]({{page page='nuxeo-search-client-elasticsearch'}}), and [Nuxeo Search Client MongoDB Atlas]({{page page='nuxeo-search-client-mongoatlas'}}).
 
 ## Configuring Nuxeo to Access the Search Cluster
@@ -756,6 +758,10 @@ Then follow the same 4-step procedure described above.
 
 You can perform reindexing without interruption across different search implementations:
 
+{{#> callout type='warning' heading='This covers the repository index only'}}
+The procedures below migrate the repository index. The audit logs index is a primary storage that cannot be rebuilt from the repository, so it has to be migrated separately by [copying the audit backend]({{page page='copy-audit-backend'}}). See [Migrating Search Technology]({{page page='search-setup-migration'}}) for the full picture.
+{{/callout}}
+
 ##### OpenSearch1 to OpenSearch2 Migration
 
 This migration reindexes from a blue index in OpenSearch1 to a green index in OpenSearch2.
@@ -863,6 +869,8 @@ For mapping customization examples, see the page [Configuring the Elasticsearch 
 ### Updating the Audit Logs Index Configuration
 
 Here the index is a primary storage and you cannot rebuild it. So we need a tool that will extract the `_source` of documents from one index and submit it to a new index that have been setup with the new configuration.
+
+This procedure applies when you keep the same search implementation and only need to apply a new mapping or new settings. To move the audit to a different implementation or a different cluster, copy the audit backend instead — see [Migrating Search Technology]({{page page='search-setup-migration'}}).
 
 {{#> callout type='warning' heading='Finish the migration before restarting'}}
 The audit index is a primary storage: unlike the repository index, it cannot be rebuilt from the repository. Once you stop the Nuxeo Platform to copy the entries, do not start it again — and do not delete the source index — until the `_reindex` request has completed and both indexes report the same document count. Audit entries that were not copied are lost permanently.

--- a/src/nxdoc/nuxeo-server/administration/search-setup/search-setup-migration.md
+++ b/src/nxdoc/nuxeo-server/administration/search-setup/search-setup-migration.md
@@ -1,0 +1,98 @@
+---
+title: Migrating Search Technology
+description: What has to be migrated when you change search technology in Nuxeo LTS 2025 — repository index, audit logs index and uid sequencer — and which procedure applies to each.
+review:
+    comment: ''
+    date: '2026-09-02'
+    status: ok
+labels:
+    - elasticsearch
+    - elasticsearch-component
+toc: true
+confluence:
+    ajs-parent-page-id: '20518480'
+    ajs-parent-page-title: Search Setup
+    ajs-space-key: NXDOC
+    ajs-space-name: Nuxeo Platform Developer Documentation
+tree_item_index: 1012
+---
+
+{{! excerpt}}
+Changing search technology — such as moving from OpenSearch 1.x to OpenSearch 2.x, or to Elasticsearch 9.x — involves more than migrating the document repository index. This page outlines all the components that require migration and links to the appropriate procedure for each.
+{{! /excerpt}}
+
+## What Must Be Migrated
+
+Nuxeo uses three indexes on the search cluster, and they do not migrate the same way.
+
+| Index | Can it be rebuilt? | How to migrate it |
+| --- | --- | --- |
+| Repository index | Yes, from the repository content | [Re-index without service interruption]({{page page='search-setup'}}#reindexing), using the blue/green procedure |
+| Audit logs index | **No**, it is a primary storage | [Copy the audit backend]({{page page='copy-audit-backend'}}), using the `copyAudit` bulk action |
+| UID sequencer index | Not applicable | Nothing to do, see [UID Sequencer](#uid-sequencer) |
+
+{{#> callout type='warning' heading='The audit index is not covered by the repository procedure'}}
+The blue/green re-indexing procedure migrates the repository index only. The audit logs index is a primary storage that cannot be rebuilt from the repository, so it has to be migrated separately. If you change search technology without migrating the audit backend, your audit entries remain on the previous cluster.
+{{/callout}}
+
+## Before You Start
+
+- **Nuxeo version.** Re-indexing the repository without service interruption requires LTS 2025.11 or later. Copying an audit backend requires LTS 2025.19 or later.
+- **Disk space.** The source and target indexes exist at the same time during the migration, so size your target cluster accordingly.
+- **Packages.** Install the search client package of the target technology, and its audit package if you store the audit on the search cluster. See the dedicated setup guide for your target stack in the table on the [Search Setup]({{page page='search-setup'}}) page.
+
+## Repository Index
+
+The repository index is rebuilt by re-indexing the repository content, so there is no data to copy. Since LTS 2025.11 this can be done without service interruption, using a blue/green index: the current index keeps serving search requests while the new one is populated, and you switch over when you are satisfied with it.
+
+The same procedure covers moving to a different cluster and moving to a different search implementation. See [Re-index Repository Without Service Interruption]({{page page='search-setup'}}#reindexing), and in particular the [Cross-Implementation Reindexing]({{page page='search-setup'}}#cross-implementation-reindexing) section for the OpenSearch 1.x to OpenSearch 2.x and OpenSearch 1.x to Elasticsearch 9.x variants.
+
+{{#> callout type='tip' heading='Upgrading from LTS 2023 without an up-front re-index'}}
+Since the OpenSearch 2.x search client addon 2025.5, an LTS 2025 instance can query an index built by LTS 2023, which lets you defer the repository re-index instead of running it before going live.
+
+The LTS 2023 and LTS 2025 mappings differ by a single field, `ecm:ancestorId`, which LTS 2025 populates at index time and an LTS 2023 index does not have. LTS 2025 resolves `ecm:ancestorId` NXQL clauses as a direct term query on that field, so on a 2023 index they would match nothing. Enable the legacy compatibility flag on the default OpenSearch 2.x client for the transition window:
+
+```
+nuxeo.opensearch2.legacyAncestorIdSearch=true
+```
+
+The client then rewrites those clauses to the `ecm:path STARTSWITH` form used by LTS 2023, so they match documents indexed by 2023.
+
+You can then run the blue/green procedure above to re-index onto a new OpenSearch 2.x cluster without service interruption, and remove the flag once that is done. Do not set it on the green client: once the green index is populated by LTS 2025, `ecm:ancestorId` is present and the native query must be used.
+{{/callout}}
+
+## Audit Logs Index
+
+The audit logs index cannot be rebuilt, so its entries have to be copied to the new backend. Since LTS 2025.19, Nuxeo provides a blue/green audit migration: a `copyAudit` bulk action copies log entries from one [Audit Backend]({{page page='audit'}}#audit-back-ends) to another, and Management endpoints trigger and verify the copy.
+
+Nuxeo performs the copy itself, reading entries from the source backend and writing them to the target one. The two backends can therefore use different technologies — OpenSearch 1.x to OpenSearch 2.x, for instance, or a SQL backend to OpenSearch.
+
+See [Copy an Audit Backend]({{page page='copy-audit-backend'}}) for the procedure, and the [Audit Router]({{page page='audit-router'}}) page for declaring the second backend and mirroring live ingestion to it while the historical entries are copied.
+
+{{#> callout type='info' heading='Changing only the mapping or settings'}}
+If you are not changing search technology, and only need to apply a new mapping or new settings to the audit index of the same implementation, use the [Updating the Audit Logs Index Configuration]({{page page='search-setup'}}#updating-the-audit-logs-index-configuration) procedure instead.
+{{/callout}}
+
+## UID Sequencer
+
+The sequencer index, configured with `nuxeo.uidsequencer.default.<namespace>.index.name`, is also a primary storage, but it does not need to be migrated: the audit backends that use it initialize the sequence to the right value when the Nuxeo Platform starts.
+
+## Verifying the Migration
+
+- **Repository index** — run a query against the new index with `GET /nuxeo/api/v1/management/search/checkSearch`, and test your Page Providers against it, as described in the [re-indexing procedure]({{page page='search-setup'}}#reindexing).
+- **Audit logs index** — compare the content of both backends with `GET /nuxeo/api/v1/management/audit/checkSearch`, passing one `backend` parameter per backend to compare.
+- **Progress** — both the repository re-indexing and the audit copy run as [Bulk Actions]({{page page='bulk-action-framework'}}) and return a `commandId` you can poll for status.
+
+## Rolling Back
+
+For the repository index, the previous index is not deleted and remains available: if you encounter a problem after switching, revert the configuration change and perform another rolling restart.
+
+For the audit logs index, the copy only reads from the source backend, which therefore still holds every entry it had: to go back, revert the configuration that promoted the new backend as the default. Entries ingested after that switch exist only in the new backend, unless you kept a [route]({{page page='audit-router'}}#routes-extension-point) mirroring ingestion to both.
+
+## Learn More
+
+- [Search Setup]({{page page='search-setup'}})
+- [Copy an Audit Backend]({{page page='copy-audit-backend'}})
+- [Audit Router]({{page page='audit-router'}})
+- [Bulk Action Framework]({{page page='bulk-action-framework'}})
+- [How to upgrade to New Search Service]({{page page='how-to-upgrade-search-service'}})

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-elasticsearch9.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-elasticsearch9.md
@@ -3,7 +3,7 @@ title: Elasticsearch 9.x Audit Backend
 description: Elasticsearch 9.x Audit Backend for Nuxeo — installation, available configuration properties.
 review:
     comment: ''
-    date: '2026-05-07'
+    date: '2026-09-02'
     status: ok
 labels:
     - audit
@@ -25,6 +25,10 @@ It deploys the `elasticsearch9-audit` template, which sets
 `org.nuxeo.audit.elasticsearch9.ElasticsearchAuditBackendFactory` and
 contributes a default `audit/default` Elasticsearch client and index named
 `nuxeo-audit`.
+
+{{#> callout type='warning' }}
+Make sure you read the [Backing Up and Restoring the Audit Elasticsearch Index]({{page page='backup-and-restore'}}#backingupandrestoringtheauditelasticsearchindex) section.
+{{/callout}}
 
 ## Configuration
 
@@ -62,6 +66,10 @@ contributes a default `audit/default` Elasticsearch client and index named
 | `nuxeo.audit.backend.default.elasticsearch9.settings.numberOfShards`                 | `5`       | Number of primary shards.                  |
 | `nuxeo.audit.backend.default.elasticsearch9.settings.numberOfReplicas`               | `1`       | Number of replicas.                        |
 | `nuxeo.audit.backend.default.elasticsearch9.settings.ignoreMalformed`                | `true`    | Ignore malformed values during indexing.   |
+
+## Migrating From Another Backend
+
+To move existing audit entries from another backend to this one — for instance when upgrading from OpenSearch 1.x — copy the audit backend instead of copying the index at cluster level. See [Copy an Audit Backend]({{page page='copy-audit-backend'}}) and [Migrating Search Technology]({{page page='search-setup-migration'}}).
 
 ## Learn More
 

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch2.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/audit-backend-opensearch2.md
@@ -3,7 +3,7 @@ title: OpenSearch 2.x Audit Backend
 description: OpenSearch 2.x Audit Backend for Nuxeo — installation, available configuration properties.
 review:
     comment: ''
-    date: '2026-05-07'
+    date: '2026-09-02'
     status: ok
 labels:
     - audit
@@ -24,6 +24,10 @@ It deploys the `opensearch2-audit` template, which sets
 `nuxeo.audit.backend.default.factory` to
 `org.nuxeo.audit.opensearch2.OpenSearchAuditBackendFactory` and contributes a
 default `audit/default` OpenSearch client and index named `nuxeo-audit`.
+
+{{#> callout type='warning' }}
+Make sure you read the [Backing Up and Restoring the Audit Elasticsearch Index]({{page page='backup-and-restore'}}#backingupandrestoringtheauditelasticsearchindex) section.
+{{/callout}}
 
 ## Configuration
 
@@ -71,6 +75,10 @@ property falls back to its `nuxeo.opensearch2.*` equivalent.
 | `nuxeo.audit.backend.default.opensearch2.settings.numberOfShards`                 | `5`       | Number of primary shards.                  |
 | `nuxeo.audit.backend.default.opensearch2.settings.numberOfReplicas`               | `1`       | Number of replicas.                        |
 | `nuxeo.audit.backend.default.opensearch2.settings.ignoreMalformed`                | `true`    | Ignore malformed values during indexing.   |
+
+## Migrating From Another Backend
+
+To move existing audit entries from another backend to this one — for instance when upgrading from OpenSearch 1.x — copy the audit backend instead of copying the index at cluster level. See [Copy an Audit Backend]({{page page='copy-audit-backend'}}) and [Migrating Search Technology]({{page page='search-setup-migration'}}).
 
 ## Learn More
 

--- a/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/copy-audit-backend.md
+++ b/src/nxdoc/nuxeo-server/data-store/data-modeling/audit/copy-audit-backend.md
@@ -3,7 +3,7 @@ title: Copy an Audit Backend
 description: Copy log entries from one Audit Backend to another using the audit scroll, the copyAudit bulk action and the Management REST API.
 review:
     comment: ''
-    date: '2026-05-07'
+    date: '2026-09-02'
     status: ok
 labels:
     - audit
@@ -75,8 +75,8 @@ Three Management endpoints expose the copy / verification flow:
 
 ## Typical Blue/Green Migration
 
-1. Deploy a secondary Audit Backend (referred to as the green backend, the live one being the default)
-   the `default` backend) — see the [Audit Router]({{page page='audit-router'}})
+1. Deploy a secondary Audit Backend — referred to as the green backend, the
+   live one being the `default` backend — see the [Audit Router]({{page page='audit-router'}})
    page.
 2. Contribute a [route]({{page page='audit-router'}}#routes-extension-point) to start mirroring live ingestion to the `green`
    backend.
@@ -101,3 +101,4 @@ reused to provide an uninterrupted **Audit Purge** capability.
 - [Audit Router]({{page page='audit-router'}})
 - [Audit Endpoint]({{page space='rest-api' version='1' page='audit-endpoint'}})
 - [Bulk Action Framework]({{page page='bulk-action-framework'}})
+- [Migrating Search Technology]({{page page='search-setup-migration'}})

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2023-to-lts-2025.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2023-to-lts-2025.md
@@ -3,7 +3,7 @@ title: Upgrade from LTS 2023 to LTS 2025
 description: Instructions to upgrade your Nuxeo Platform instance from LTS 2023 version to LTS 2025.
 review:
   comment: ''
-  date: '2025-02-28'
+  date: '2026-09-02'
   status: ok
 labels:
   - multiexcerpt
@@ -286,7 +286,9 @@ curl -u USERNAME:PASSWORD -XPOST https://NUXEO_INSTANCE/nuxeo/api/v1/management/
 
 A full repository re-index is required to apply the new index mapping, even if your target search engine remains OpenSearch 1.x / Elasticsearch 7.x–8.x. See the [repository re-indexing procedure]({{page page='search-setup'}}#reindex).
 
-If you remain on OpenSearch 1.x / Elasticsearch 7.x–8.x, the audit index can be kept unchanged. If you switch to a different search engine, migrate the audit index to the new cluster. Refer to the OpenSearch or Elasticsearch documentation.
+It does not have to be done before going live. Using the OpenSearch 2.x search client with its legacy compatibility option, an LTS 2025 instance can query an index built by LTS 2023, so the re-index can be deferred to a blue/green migration that runs without service interruption. See [Migrating Search Technology]({{page page='search-setup-migration'}}).
+
+If you remain on OpenSearch 1.x / Elasticsearch 7.x–8.x, the audit index can be kept unchanged. If you switch to a different search engine, the audit index has to be migrated separately from the repository index: it is a primary storage and cannot be rebuilt. See [Migrating Search Technology]({{page page='search-setup-migration'}}).
 
 ### Relation Document Indexing
 


### PR DESCRIPTION
[NXDOC-3014](https://hyland.atlassian.net/browse/NXDOC-3014) — also closes out [NXDOC-3018](https://hyland.atlassian.net/browse/NXDOC-3018), which is the same gap seen from the audit side.

> **Stacked on #2826.** Based on `NXDOC-3015-migration-restart-warning-2025`, not on `2025`, because both changes edit the same paragraph of the audit procedure in `search-setup.md`. GitHub retargets this to `2025` automatically when #2826 merges. Review #2826 first.

## Problem

Changing search technology (OpenSearch 1.x → OpenSearch 2.x, or → Elasticsearch 9.x) requires migrating **three** things. Only one of them was documented anywhere a reader would find it.

Both mechanisms already exist:
- **Repository index** — full blue/green procedure in `search-setup.md` (LTS 2025.11+), including cross-implementation variants.
- **Audit index** — the `copyAudit` bulk action, `POST /management/audit/copy` and `GET /management/audit/checkSearch`, documented on [Copy an Audit Backend](https://doc.nuxeo.com/nxdoc/copy-audit-backend/) (LTS 2025.19+).

The problem is that the audit mechanism is invisible from every page an operator starts on, and one line actively pointed the wrong way:

1. `upgrade-from-lts-2023-to-lts-2025.md` said *"If you switch to a different search engine, migrate the audit index to the new cluster. **Refer to the OpenSearch or Elasticsearch documentation.**"* — punting to third-party docs when Nuxeo has its own supported mechanism.
2. *Cross-Implementation Reindexing* covers the repository index only and never says audit is separate. Followed literally, it strands audit entries on the previous cluster — and audit is a primary storage that **cannot be rebuilt**.
3. The legacy offline `_reindex` audit procedure never said which case it applies to (a same-implementation mapping change), so it reads as the migration path.
4. The OpenSearch 2.x and Elasticsearch 9.x audit backend pages said nothing about existing data.
5. `copy-audit-backend` was reachable only from `audit.md` "Learn More" and `audit-router.md`.

Worth noting for anyone who saw the original tickets: NXDOC-3018 was framed as needing a PM decision on warning strength, and NXDOC-3014 as "no migration docs exist". Neither holds — the mechanism exists and is supported, so this is a routing and discoverability fix, not new guidance.

## Change

**New page** `search-setup/search-setup-migration.md` — *Migrating Search Technology*, a child of Search Setup. It **routes rather than restates**: no procedure text is duplicated, so nothing can drift out of sync. Its core is one table that answers what has to be migrated:

| Index | Rebuildable? | How |
| --- | --- | --- |
| Repository index | Yes, from repository content | blue/green re-index |
| Audit logs index | **No** — primary storage | copy the audit backend |
| UID sequencer index | N/A | nothing to do, re-initialised at startup |

Those three facts currently live in three different pages. It also covers version prerequisites (2025.11 / 2025.19), verification endpoints for both indexes, and what rollback looks like for each.

**Cross-links added** from the Search Setup stack table, the Cross-Implementation Reindexing section (with a callout stating it covers the repository index only), the audit `_reindex` procedure (now says which case it is for), the LTS 2023→2025 upgrade guide, both newer audit backend pages, and `copy-audit-backend`'s Learn More.

**Drive-by fix:** `copy-audit-backend.md` step 1 was garbled — *"(referred to as the green backend, the live one being the default) the `default` backend)"*, a duplicated fragment with an unmatched paren.

## Verification

No build exists anywhere — deps aren't installed locally and the repo has no CI — so **rendering and tree placement could not be confirmed**. Please confirm on an environment that does build. To de-risk it, the new page's frontmatter is key-for-key identical to `search-setup-opensearch2.md` (same `confluence.ajs-parent-page-id`), changing only title, description, review date and `tree_item_index` (1012, placing it after the four per-stack guides).

What was checked statically:
- **Frontmatter YAML** — real `YAML.load` parse of all six touched files, via ruby. All pass.
- **Cross-references** — every `{{page page='...'}}` in the new page resolves (6/6). Repo-wide unresolved refs: **59 before, 59 after, identical sets** — no new dead links. (That 59 baseline is pre-existing and does not break the build.)
- **Structure** — callout open/close balanced on every file; code-fence parity even.

## Notes

- The two backup/restore callouts I added for parity with `audit-backend-opensearch1.md` point at a `backup-and-restore.md` section that is **stale for LTS 2025** — it still uses `audit.elasticsearch.*` property names and links a page that no longer exists on this branch. The "back up your audit index" message is important enough to surface on all three backend pages, but flagging that the target needs its own update.
- `2025` only. `copyAudit` is 2025.19+, so LTS 2023 has no equivalent path and this guidance does not backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)