### PR TITLE
NXDOC-3019: Update search passthrough page for LTS 2025

### DIFF
--- a/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
+++ b/src/nxdoc/nuxeo-server/administration/configuration-parameters-index-nuxeoconf.md
@@ -2090,6 +2090,30 @@ Limit the binary fulltext size during indexing to improve search engine performa
 
 * * *
 
+#### `nuxeo.passthrough.elasticsearch.enabled`
+
+Enable the [Search Passthrough]({{page page='elasticsearch-passthrough'}}) for the repository index. Set to `false` to disable it.
+
+**Since `nuxeo-search-client-opensearch2` 2025.5**
+
+**Default Value**
+
+`true`
+
+* * *
+
+#### `nuxeo.passthrough.elasticsearch.audit.enabled`
+
+Enable the [Search Passthrough]({{page page='elasticsearch-passthrough'}}) for the audit index. Set to `false` to disable it.
+
+**Since `nuxeo-audit-opensearch2` 2025.5**
+
+**Default Value**
+
+`true`
+
+* * *
+
 #### `nuxeo.search.indexing.enabled`
 
 Master switch enabling the search indexing subsystem: the `ongoingIndexing` stream processor and the `bulk/indexing` and `bulk/indexingBackground` bulk actions. Set to `false` to disable all search indexing.

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-passthrough.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-passthrough.md
@@ -114,12 +114,12 @@ The Nuxeo passthrough is available at **http://my-nuxeo-server:8080/nuxeo/site/e
 
 ### Requirement
 
-When your OpenSearch instance is embedded on the same JVM as your Nuxeo instance (not recommended for production), the passthrough works out of the box.
+The passthrough works out of the box, it reuses the OpenSearch/Elasticsearch client configured for the Nuxeo instance, no additional base URL configuration is required.
 
-When using a remote OpenSearch/Elasticsearch cluster, make sure the following property is correctly set in your [nuxeo.conf]({{page page='configuration-parameters-index-nuxeoconf'}}):
+The passthrough is enabled by default. It can be disabled by setting the following property in your [nuxeo.conf]({{page page='configuration-parameters-index-nuxeoconf'}}):
 
 ```
-elasticsearch.httpReadOnly.baseUrl=http://your_es_instance:9200
+nuxeo.passthrough.elasticsearch.enabled=false
 ```
 
 ### Querying Indexes


### PR DESCRIPTION
https://hyland.atlassian.net/browse/NXDOC-3019

- `elasticsearch.httpReadOnly.baseUrl` is no longer used/required, passthrough reuses the configured OpenSearch/Elasticsearch client.
- Document the `nuxeo.passthrough.elasticsearch.enabled` / `nuxeo.passthrough.elasticsearch.audit.enabled` properties to disable the passthrough, and add them to the nuxeo.conf parameters reference.