### PR TITLE
NXDOC-3017: Route the LTS 2025 upgrade content

### DIFF
--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform.md
@@ -3,7 +3,7 @@ title: Upgrade
 description: This page describes a general upgrade procedure. You will find below the list of required manual steps per version.
 review:
     comment: ''
-    date: '2020-07-29'
+    date: '2026-09-10'
     status: ok
 labels:
     - content-review-lts2016
@@ -466,8 +466,10 @@ You should have [configured Nuxeo with a specific configuration]({{page page='se
         {{#> callout type='warning' }}
         Be very careful about the two properties allowing to configure the backend for audit logs, make sure you read the related documentation:
 
-        *   `audit.elasticsearch.enabled`: [Disabling Elasticsearch for Audit Logs]({{page page='elasticsearch-setup'}}#disabling-elasticsearch-for-audit-logs)
+        *   `audit.elasticsearch.enabled`: [Disabling Elasticsearch for Audit Logs]({{page page='search-setup'}}#disabling-elasticsearch-for-audit-logs)
         *   `audit.elasticsearch.migration`: [Triggering SQL to Elasticsearch Audit Logs Migration]({{page version='810' page='elasticsearch-setup'}}#triggering-sql-to-elasticsearch-audit-logs-migration)
+
+        Starting with LTS 2025, these two properties have no effect. The audit backend is selected by installing the corresponding Marketplace Package, and Nuxeo Server ships with an in-memory implementation that is for testing only — so an upgrade that installs no audit package stores no audit durably. See [How to upgrade Nuxeo Audit Service]({{page page='how-to-upgrade-audit-service'}}).
         {{/callout}}
         *   Replace the old nuxeo.conf file with this new one.
 6.  [Upgrade your Nuxeo Packages](#marketplace-packages-upgrade).
@@ -509,6 +511,12 @@ Since the Platform evolves, you will also need to upgrade your custom code:
 
 ## Detailed Upgrade by Version
 
+### To Nuxeo LTS 2025 from LTS 2023
+See [Upgrade from LTS 2023 to LTS 2025]({{page space='nxdoc' page='upgrade-from-lts-2023-to-lts-2025'}}) for the upgrade notes, and [How to upgrade to LTS 2025.0]({{page space='nxdoc' page='how-to-upgrade-from-lts-2023-to-lts-2025'}}) for the API migration guides: Jakarta EE 10, Jakarta RS 3, Search Service, Audit Service and REST tests.
+
+Release Notes:
+- [Nuxeo Platform LTS 2025 Release notes]({{page page='nuxeo-server-release-notes-2025-0'}})
+
 ### To Nuxeo LTS 2023 from LTS 2021
 See [Upgrade from LTS 2021 to LTS 2023]({{page space='nxdoc' page='upgrade-from-lts-2021-to-lts-2023'}}) to upgrade to the LTS 2023 version of Nuxeo Platform.
 
@@ -529,7 +537,7 @@ Release Notes:
 
 ### To LTS 2017 from LTS 2016
 
-See [Upgrade from LTS 2016 to LTS 2017]({{page version='' space='nxdoc' page='upgrade-from-lts-2016-to-LTS-2017'}}) to upgrade to the LTS 2017 version or [Upgrade from LTS 2016 following Fast Tracks]({{page version='' space='' page='upgrade-from-lts-2016-following-fast-tracks'}}) to upgrade from a Fast Track version to LTS 2017.
+See [Upgrade from LTS 2016 to LTS 2017]({{page version='' space='nxdoc' page='upgrade-from-lts-2016-to-lts-2017'}}) to upgrade to the LTS 2017 version or [Upgrade from LTS 2016 following Fast Tracks]({{page version='' space='' page='upgrade-from-lts-2016-following-fast-tracks'}}) to upgrade from a Fast Track version to LTS 2017.
 
 Release notes:
 - [9.x Release notes]({{page version='910' space='nxdoc' page='nuxeo-server-release-notes'}})

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/how-to-upgrade-from-lts-2023-to-lts-2025.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/how-to-upgrade-from-lts-2023-to-lts-2025.md
@@ -3,7 +3,7 @@ title: How to upgrade to LTS 2025.0
 description: Discover what changed in LTS 2025.0
 review:
    comment: ''
-   date: '2025-03-10'
+   date: '2026-09-10'
    status: ok
 labels:
     - release-notes
@@ -14,6 +14,8 @@ tree_item_index: 93
 Nuxeo LTS 2025 has breaking changes when you upgrade your project from a previous Nuxeo version.
 
 You will find in this section how to upgrade your Nuxeo Server project with new Jakarta Standards and Nuxeo APIs.
+
+For the infrastructure, configuration and deprecation notes that go with this upgrade, see [Upgrade from LTS 2023 to LTS 2025]({{page page='upgrade-from-lts-2023-to-lts-2025'}}). For the general upgrade procedure, see [Upgrading the Nuxeo Platform]({{page page='upgrading-the-nuxeo-platform'}}).
 
 ## How to Upgrade to Jakarta EE 10
 

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2023-to-lts-2025.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2023-to-lts-2025.md
@@ -17,6 +17,8 @@ For the general upgrade process, see the page [Upgrading the Nuxeo Platform]({{p
 This chapter highlights some major information about upgrade from Nuxeo Platform LTS 2023 (2023.x) to Nuxeo Platform LTS 2025 (2025.x). We strongly encourage you to also have a quick read of the upgrade notes.
 {{! /excerpt}}
 
+This page covers infrastructure, configuration and deprecations. For the API changes your project code has to follow — Jakarta EE 10, Jakarta RS 3, the new Search Service, the Audit Service and REST tests — see [How to upgrade to LTS 2025.0]({{page page='how-to-upgrade-from-lts-2023-to-lts-2025'}}).
+
 ## Prerequisites
 
 These upgrade notes assume that Nuxeo Server is on 2023 and up to date with the latest hotfixes.


### PR DESCRIPTION
[NXDOC-3017](https://hyland.atlassian.net/browse/NXDOC-3017)

Javier's feedback was that the upgrade guide "may still not be sufficient". No specifics were captured, so I audited the pages instead of guessing. The content is not thin — it is unreachable. This PR fixes that half; the remaining gaps stay on the ticket.

## Problem

**1. The general upgrade page never got an LTS 2025 entry.** `upgrading-the-nuxeo-platform.md` contains **zero** occurrences of "2025". Its *Detailed Upgrade by Version* list runs 2023, 2021, 2019, 2017, 2016, 2015 — every prior LTS has an entry. The page that owns the upgrade procedure does not reach the version you are upgrading to.

**2. The LTS 2025 notes are linked from exactly one file in the repo** — `nuxeo-server-release-notes.md`. Nothing in the upgrade section links them, so discovery depends entirely on the nav tree.

**3. There are two sibling LTS 2025 pages that never referenced each other:**

| Page | tree | Lines | Content |
| --- | --- | --- | --- |
| Upgrade from LTS 2023 to LTS 2025 | 92 | 473 | infrastructure, configuration, deprecations |
| How to upgrade to LTS 2025.0 | 93 | 1,480 across 5 sub-pages | Jakarta EE 10, Jakarta RS 3, Search Service, Audit Service, REST tests |

Links between them, either direction: **0**. Someone landing on the upgrade notes reads 473 lines with no indication that 1,480 lines of API migration guidance sit next door. That is the most likely explanation for the "not sufficient" reaction.

Worth noting the volume complaint does not hold up: 473 looks thin against 1,914 (2021→2023) and 1,717 (2019→2021), but 473 + 1,480 = **1,953** — slightly more than 2021→2023. The content was reorganised, not reduced. Only the routing was lost.

**4. The one prominent warning in the general procedure is stale and its link 404s.** It tells you to be "very careful" with `audit.elasticsearch.enabled` and `audit.elasticsearch.migration` and links `{{page page='elasticsearch-setup'}}` — a page that does not exist on this branch. Per *How to upgrade Nuxeo Audit Service*, `audit.elasticsearch.enabled` has no effect in LTS 2025.

## Change

- Added the **To Nuxeo LTS 2025 from LTS 2023** entry to the version list, following the existing per-version pattern and pointing at both LTS 2025 pages plus the LTS 2025 release notes.
- Cross-linked the two LTS 2025 pages, each stating what the other covers.
- Kept the legacy audit properties documented (still correct for older targets) and added that they have no effect from LTS 2025 on — including the part that seems worth saying out loud: Nuxeo Server ships an **in-memory** audit implementation intended for testing, so an upgrade that installs no audit package stores no audit durably.
- Retargeted the dead `elasticsearch-setup` link to `search-setup`, which carries the same `#disabling-elasticsearch-for-audit-logs` anchor, and fixed the casing (`LTS-2017` → `lts-2017`) that broke the LTS 2016 → LTS 2017 link.

## Deliberately not in this PR

Three gaps that need Platform input rather than a routing fix, left on NXDOC-3017:

- **No rollback guidance anywhere.** 0 occurrences of rollback / roll back / revert on the parent page. There is "take a backup" and never "here is how to go back" — for an upgrade with a mandatory full re-index.
- **No post-upgrade validation** beyond step 11, "check for ERROR or WARN in the logs". 0 occurrences of validat / verif.
- **No duration or sizing guidance.** 0 occurrences of downtime / duration / sizing, which matters here specifically because of the mandatory re-index.

## Separate finding, not actioned

The `elasticsearch-setup` → `search-setup` rename left **22 unversioned broken references across 19 files** on this branch (only 1 of the 23 is a legitimate `version='810'` cross-space link, which I left alone). Each needs its anchor checked individually, so it wants its own sweep rather than being smuggled in here.

## Verification

No build available — deps are not installable locally and the repo has no CI — so rendering is unverified. Checked statically:

- **Frontmatter YAML** parsed with `YAML.load` on all three files: pass.
- **Dead refs contributed by these three files: 2 before → 1 after.** The remaining one is the deliberate `version='810'` link. All seven page ids I added resolve.
- Callout open/close balance and code-fence parity unchanged.

I did not bump the `review` date on `upgrade-from-lts-2023-to-lts-2025.md`: #2828 already refreshes it, and touching the same frontmatter line would create a pointless conflict. Its content hunk here is far from #2828's, so the two should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)