### PR TITLE
  NXDOC-3024: Retarget the elasticsearch-setup references to search-setup

### DIFF
--- a/src/nxdoc/dam/search-and-find.md
+++ b/src/nxdoc/dam/search-and-find.md
@@ -18,7 +18,7 @@ The Nuxeo Platform provides different way to search your documents. Searches can
 
 The search enables you to search a document using documents metadata. You can for instance select metadata of the searched document or the date of specific events such as publication, creation.
 
-The Search tab leverages [Elasticsearch]({{page version='' space='nxdoc' page='elasticsearch-setup'}}) to provide a quicker and more efficient search. The search form uses Elasticsearch aggregates for most fields: aggregate fields values are filtered so as to display only relevant values and show the count of matching documents for each value.
+The Search tab leverages [Elasticsearch]({{page version='' space='nxdoc' page='search-setup'}}) to provide a quicker and more efficient search. The search form uses Elasticsearch aggregates for most fields: aggregate fields values are filtered so as to display only relevant values and show the count of matching documents for each value.
 
 ### Assets Search
 

--- a/src/nxdoc/getting-started/use-cases/bootstrap-your-document-management-project.md
+++ b/src/nxdoc/getting-started/use-cases/bootstrap-your-document-management-project.md
@@ -300,6 +300,6 @@ At some point in your project you need to decide about the architecture. Do you 
 
 - [Persistence Architecture]({{page page='persistence-architecture'}})
 - [Nuxeo Architecture Components - Configuration]({{page page='nuxeo-architecture-components'}})
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 
 {{/callout}}

--- a/src/nxdoc/nuxeo-server/administration/maintenance/backup-and-restore.md
+++ b/src/nxdoc/nuxeo-server/administration/maintenance/backup-and-restore.md
@@ -166,7 +166,7 @@ elasticsearch.enabled=true
 audit.elasticsearch.enabled=true
 ```
 
-you need to backup / restore `${audit.elasticsearch.indexName}` Elasticsearch index [defined in nuxeo.conf]({{page page='elasticsearch-setup'}}#configuring-nuxeo-to-access-the-elasticsearch-cluster), following the Elasticsearch&nbsp;[Snapshot And Restore](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html) documentation.
+you need to backup / restore `${audit.elasticsearch.indexName}` Elasticsearch index [defined in nuxeo.conf]({{page page='search-setup'}}#configuring-nuxeo-to-access-the-search-cluster), following the Elasticsearch&nbsp;[Snapshot And Restore](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html) documentation.
 
 Note that since Nuxeo 9.10, the sequence index `${seqgen.elasticsearch.indexName}` can be regenerated quickly at startup, so it is not mandatory to backup this index.
 
@@ -175,7 +175,7 @@ This is really important if as if you decide to use Elasticsearch as a backend f
 {{/callout}}
 
 {{#> callout type='info' }}
-Reminder: as stated in&nbsp;[Setting up an Elasticsearch Cluster]({{page page='elasticsearch-setup'}}#setting-up-an-elasticsearch-cluster), the embedded Elasticsearch mode&nbsp;**is only for testing purpose**&nbsp;and should not be used in production.
+Reminder: as stated in&nbsp;[Embedded Mode]({{page page='search-setup-opensearch1'}}#embedded-mode), the embedded Elasticsearch mode&nbsp;**is only for testing purpose**&nbsp;and should not be used in production.
 
 Yet if you decide to use it for development or tests, to perform the backup / restore operations you will need to make the embedded Elasticsearch server accept HTTP request on port 9200 by setting `elasticsearch.httpEnabled=true` in `nuxeo.conf`.
 

--- a/src/nxdoc/nuxeo-server/administration/maintenance/reporting-problems.md
+++ b/src/nxdoc/nuxeo-server/administration/maintenance/reporting-problems.md
@@ -332,7 +332,7 @@ And report the output of the following commands, assuming that Elasticsearch is 
 (ES="localhost:9200"; curl "$ES"; curl "$ES/_cat/health?v"; curl "$ES/_cat/nodes?v"; curl "$ES/_cat/indices?v") > /tmp/nuxeo-elastic-`date +%Y%m%d-%H%M%S`.txt
 ```
 
-In addition if the problem is related to unexpected search results or errors, follow this procedure: [Reporting Settings and Mapping]({{page page='elasticsearch-setup'}}#reporting-settings-and-mapping)
+In addition if the problem is related to unexpected search results or errors, follow this procedure: [Reporting Settings and Mapping]({{page page='search-setup'}}#reporting-settings-and-mapping)
 
 ## {{> anchor 'kafka'}}Kafka
 

--- a/src/nxdoc/nuxeo-server/administration/trust-store-and-key-store-configuration.md
+++ b/src/nxdoc/nuxeo-server/administration/trust-store-and-key-store-configuration.md
@@ -128,7 +128,7 @@ Use the following `nuxeo.conf` properties:
 - `elasticsearch.restClient.keystore.password`
 - `elasticsearch.restClient.keystore.type`
 
-See the [Elasticsearch Configuration]({{page page='elasticsearch-setup'}}) page for more.
+See the [Elasticsearch Configuration]({{page page='search-setup'}}) page for more.
 
 ### MongoDB
 

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/configuring-the-elasticsearch-mapping.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/configuring-the-elasticsearch-mapping.md
@@ -393,7 +393,7 @@ SELECT * FROM Document WHERE /*+ES: INDEX(dc:title.ngram) ANALYZER(lowercase_ana
 {{#> panel heading='Other Elasticsearch Documentation'}}
 
 - [Search Indexing Logic]({{page page='elasticsearch-indexing-logic'}})
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 - [How to Make a Page Provider or Content View Query Elasticsearch Index]({{page page='how-to-make-a-page-provider-or-content-view-query-elasticsearch-index'}})
 
 {{/panel}}</div><div class="column medium-4">

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-indexing-logic.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-indexing-logic.md
@@ -250,7 +250,7 @@ Only the simplified ACL is supported with Elasticsearch (this is the default sec
 <div class="row" data-equalizer data-equalize-on="medium"><div class="column medium-6">{{#> panel heading='Other Elasticsearch Documentation'}}
 
 - [Configuring the Elasticsearch Mapping]({{page page='configuring-the-elasticsearch-mapping'}})
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 - [How to Make a Page Provider or Content View Query Elasticsearch Index]({{page page='how-to-make-a-page-provider-or-content-view-query-elasticsearch-index'}})
 
 {{/panel}}</div><div class="column medium-6">{{#> panel heading='Indexing related pages'}}

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-passthrough.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/elasticsearch-passthrough.md
@@ -217,7 +217,7 @@ The [RoutingAuditRequestFilter](https://github.com/nuxeo/nuxeo/blob/master/modul
 <div class="row" data-equalizer data-equalize-on="medium"><div class="column medium-6">{{#> panel heading='Related Documentation'}}
 
 - [Workflow Audit Log]({{page page='workflow-audit-log'}})
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 - [Search Indexing Logic]({{page page='elasticsearch-indexing-logic'}})
 - [Configuring the Elasticsearch Mapping]({{page page='configuring-the-elasticsearch-mapping'}})
 - [Security Policy Service]({{page page='security-policy-service'}})

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/indexing-and-querying-how-to-index/how-to-configure-a-search-filter-with-facets-and-other-aggregates.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/indexing-and-querying-how-to-index/how-to-configure-a-search-filter-with-facets-and-other-aggregates.md
@@ -414,7 +414,7 @@ This aggregate allows you to define a set of ranges and works as the date range 
 
 <div class="row" data-equalizer data-equalize-on="medium"><div class="column medium-6">{{#> panel heading='Related Documentation'}}
 
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 - [Configuring the Elasticsearch Mapping]({{page page='configuring-the-elasticsearch-mapping'}})
 - [Aggregate Widget Types]({{page page='aggregate-widget-types'}})
 - [How to Make a Page Provider or Content View Query Elasticsearch Index]({{page page='how-to-make-a-page-provider-or-content-view-query-elasticsearch-index'}})

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/indexing-and-querying-how-to-index/how-to-make-a-page-provider-or-content-view-query-elasticsearch-index.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/indexing-and-querying-how-to-index/how-to-make-a-page-provider-or-content-view-query-elasticsearch-index.md
@@ -176,7 +176,7 @@ Elasticsearch indexing is "eventually consistent". This means that depending on 
 <div class="row" data-equalizer data-equalize-on="medium"><div class="column medium-6">{{#> panel heading='Other pages about Elasticsearch'}}
 
 - [Moving Load from Database to Elasticsearch]({{page page='moving-load-from-database-to-elasticsearch'}})
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 - [Search Indexing Logic]({{page page='elasticsearch-indexing-logic'}})
 - [Configuring the Elasticsearch Mapping]({{page page='configuring-the-elasticsearch-mapping'}})
 

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/moving-load-from-database-to-elasticsearch.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/moving-load-from-database-to-elasticsearch.md
@@ -251,7 +251,7 @@ See the [OpenSearch Passthrough]({{page page='elasticsearch-passthrough'}}) page
 - [How to Make a Page Provider or Content View Query Elasticsearch Index]({{page page='how-to-make-a-page-provider-or-content-view-query-elasticsearch-index'}})
 - [Configuring the Elasticsearch Mapping]({{page page='configuring-the-elasticsearch-mapping'}})
 - [Search Indexing Logic]({{page page='elasticsearch-indexing-logic'}})
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 
 {{/panel}}</div><div class="column medium-6">
 

--- a/src/nxdoc/nuxeo-server/data-store/indexing-and-query/nxql.md
+++ b/src/nxdoc/nuxeo-server/data-store/indexing-and-query/nxql.md
@@ -997,7 +997,7 @@ Visit the [mapping documentation]({{page page='configuring-the-elasticsearch-map
 
 The full-text search is not configured the same way:
 
-*   The `ecm:fulltext` matches the `all_field` field which is the concatenation of all fields. This is different from the NXQL `ecm:fulltext` which matches only some explicit fields. You can [adapt the mapping to exclude some fields]({{page page='elasticsearch-setup'}}).
+*   The `ecm:fulltext` matches the `all_field` field which is the concatenation of all fields. This is different from the NXQL `ecm:fulltext` which matches only some explicit fields. You can [adapt the mapping to exclude some fields]({{page page='search-setup'}}).
 *   Custom full-text indexes are not supported. `ecm:fulltext_someindex` will match the `all_field` field. It is possible to select a list of field using hints, see below.
 *   In addition to the NXQL full-text syntax, it is also possible to use the Elasticsearch [simple query string syntax](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#_simple_query_string_syntax).
 

--- a/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-reference-architectures.md
+++ b/src/nxdoc/nuxeo-server/installation/nuxeo-cluster-architecture/nuxeo-reference-architectures.md
@@ -322,7 +322,7 @@ The same idea is true for all the Cloud specific services like provisioning and 
 {{/panel}}</div><div class="column medium-6">{{#> panel heading='Related Documentation'}}
 
 - [Nuxeo Architecture Components - Configuration]({{page page='nuxeo-architecture-components'}})
-- [Elasticsearch Setup]({{page page='elasticsearch-setup'}})
+- [Search Setup]({{page page='search-setup'}})
 - [HTTP and HTTPS Reverse-Proxy Configuration]({{page page='http-and-https-reverse-proxy-configuration'}})
 
 {{/panel}}</div></div>

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-58-to-60.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-58-to-60.md
@@ -238,7 +238,7 @@ nuxeo.security.allowNegativeACL=true
 
 ### Upgrading Your Production Architecture
 
-Elasticsearch is not mandatory: you can [keep on querying VCS (the database)]({{page page='elasticsearch-setup'}}#disabling-elasticsearch) and use the database full-text index.
+Elasticsearch is not mandatory: you can [keep on querying VCS (the database)]({{page page='search-setup'}}#disabling-elasticsearch) and use the database full-text index.
 
 {{#> callout type='warning' }}
 

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2016-following-fast-tracks.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2016-following-fast-tracks.md
@@ -18,7 +18,7 @@ tree_item_index: 99
 
 {{! multiexcerpt name='upgrade-9.1-reindex-warning'}}
 
-Reindex the full repository following [Rebuilding the repository index page]({{page anchor='rebuildingtheindex-rebuilding-the-repository-index' page='elasticsearch-setup'}}), or using [Nuxeo Dev Tools Extension]({{page page='nuxeo-dev-tools-extension'}}). See [NXP-21279](https://jira.nuxeo.com/browse/NXP-21279).
+Reindex the full repository following [Rebuilding the repository index page]({{page page='search-setup'}}#rebuilding-the-repository-index), or using [Nuxeo Dev Tools Extension]({{page page='nuxeo-dev-tools-extension'}}). See [NXP-21279](https://jira.nuxeo.com/browse/NXP-21279).
 
 {{! /multiexcerpt}}
 

--- a/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2019-to-lts-2021.md
+++ b/src/nxdoc/nuxeo-server/upgrading-the-nuxeo-platform/upgrade-from-lts-2019-to-lts-2021.md
@@ -591,7 +591,7 @@ you need to upgrade your existing Elasticsearch cluster to version 7.9 (7.7 or 7
 If you encounter indexing errors because of negative startOffset, your mapping needs to be updated.
 
 If you have overridden the Elastic mapping then follow the recommended changes in the ticket.
-Then you need to reindex the repository, visit the [related documentation]({{page page='elasticsearch-setup'}}#rebuilding-the-repository-index) for more information.
+Then you need to reindex the repository, visit the [related documentation]({{page page='search-setup'}}#rebuilding-the-repository-index) for more information.
 
 <i class="fa fa-long-arrow-right" aria-hidden="true"></i>&nbsp;More on JIRA ticket [NXP-30785](https://jira.nuxeo.com/browse/NXP-30785)
 
@@ -703,7 +703,7 @@ This means that there is no migration to do if your Nuxeo instance has been crea
 Follow the [Elasticsearch upgrade documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-upgrade.html) to upgrade your Elasticsearch Cluster.
 
 If you had to adapt your Elasticsearch settings or mappings for 7.x,
-you have to proceed to a [repository re-index]({{page page='elasticsearch-setup'}}#reindex) in order to apply the new configuration.
+you have to proceed to a [repository re-index]({{page page='search-setup'}}#reindex) in order to apply the new configuration.
 
 #### Migration of Elastic Indexes Created in Elasticsearch 5.x (Nuxeo 9.10/LTS 2017)
 
@@ -727,7 +727,7 @@ The `nuxeo-uidgen` index must be deleted **after** the audit index migration is 
 Only the default `uidgen` sequence is automatically re-created at startup. If you have other sequences, they must be recreated and correctly initialized to the right ID to also avoid duplicate IDs.
 {{/callout}}
 
-Once the Elasticsearch cluster is upgraded, start Nuxeo LTS 2021 and proceed to a [repository re-index]({{page page='elasticsearch-setup'}}#reindex).
+Once the Elasticsearch cluster is upgraded, start Nuxeo LTS 2021 and proceed to a [repository re-index]({{page page='search-setup'}}#reindex).
 
 ## Bulk Service (Aka "Bulk Action Framework")
 

--- a/src/nxdoc/web-ui/nuxeo-elements/quality-assurance.md
+++ b/src/nxdoc/web-ui/nuxeo-elements/quality-assurance.md
@@ -152,7 +152,7 @@ With Nuxeo platform, you have two ways of fetching data from the server for buil
 - Via 'direct' queries
 - Via [`pageproviders`]({{page version='' space='nxdoc' page='page-providers'}})
 
-Depending on your environment, you perform searches with Nuxeo Server on top of your **database** (PostgreSQL, MongoDB) or on top of your [**ElasticSearch**]({{page version='' space='nxdoc' page='elasticsearch-setup'}}) **(recommended)**.
+Depending on your environment, you perform searches with Nuxeo Server on top of your **database** (PostgreSQL, MongoDB) or on top of your [**ElasticSearch**]({{page version='' space='nxdoc' page='search-setup'}}) **(recommended)**.
 
 For Elasticsearch (ES), use `pageproviders` which [can be activated for ES]({{page version='' space='nxdoc' page='how-to-make-a-page-provider-or-content-view-query-elasticsearch-index'}}) via the `nuxeo.conf` file and the following Nuxeo elements with related properties:
 

--- a/src/userdoc/web-ui/organizing-content/search.md
+++ b/src/userdoc/web-ui/organizing-content/search.md
@@ -39,7 +39,7 @@ Pressing the "Enter" key will navigate to the first item in the suggestions. It'
 
 The Search tab enables you to search a document using documents metadata. You can for instance select metadata of the searched document or the date of specific events such as publication, creation.
 
-The Search tab leverages [Elasticsearch]({{page version='' space='nxdoc' page='elasticsearch-setup'}}) to provide a quicker and more efficient search. The search form uses Elasticsearch aggregates for most fields: aggregate fields values are filtered so as to display only relevant values and show the count of matching documents for each value.
+The Search tab leverages [Elasticsearch]({{page version='' space='nxdoc' page='search-setup'}}) to provide a quicker and more efficient search. The search form uses Elasticsearch aggregates for most fields: aggregate fields values are filtered so as to display only relevant values and show the count of matching documents for each value.
 
 ![]({{file name='search-tab-web-ui.png'}} ?w=600,border=true)
 


### PR DESCRIPTION
  The Elasticsearch Setup page became Search Setup for LTS 2025, but its
  references were not updated: 22 links across 19 files still pointed at
  a page id that does not exist on this branch. Broken page references do
  not fail the build, so they shipped as dead links rather than surfacing
  as an error.

  Three needed a new anchor as well, because the rename moved or retitled
  the section they pointed at:

  - #configuring-nuxeo-to-access-the-elasticsearch-cluster is now
    #configuring-nuxeo-to-access-the-search-cluster.
  - #setting-up-an-elasticsearch-cluster no longer exists on the parent
    page; the embedded-mode warning that link was making now lives on the
    OpenSearch 1.x page, so it points at #embedded-mode there.
  - The legacy Confluence anchor written in the rare anchor= attribute
    form is now the #anchor form used everywhere else in the repo.

  Two references are deliberately unchanged: version='810' and
  space='admindoc60' resolve against documentation spaces where the old
  page still exists.
